### PR TITLE
F2calv/2026 04 updates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -171,7 +171,7 @@ string? floor = null
 
 - Always set `fetch-depth: 0` on checkout when GitVersion is in use.
 - Default config file is `GitVersion.yml` in the repository root.
-- Prefer `semVer` for tags and releases; use `fullSemVer` for display and pre-release identifiers.
+- Prefer `semVer` for tags and releases; use `fullSemVer` (via the `version` output) for build versioning and pre-release identifiers.
 
 ## Documentation
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ on:
     branches-ignore:
       - "preview/**"
     paths-ignore:
+      - .github/copilot-instructions.md
       - LICENSE
       - README.md
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,19 @@ on:
           - Debug
       push-preview:
         type: string
-        description: Push preview branch?
+        description: Push a pre-release NuGet package from a non-default branch?
         required: true
         default: "false"
+      execute-tests:
+        type: string
+        description: Execute unit tests?
+        required: false
+        default: "true"
+      package-filter:
+        type: string
+        description: Comma-separated package ID prefixes to push e.g. CasCap.Common.Caching
+        required: false
+        default: ''
   push:
     branches-ignore:
       - "preview/**"
@@ -51,7 +61,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
           configuration: ${{ inputs.configuration }}
+          execute-tests: ${{ inputs.execute-tests }}
           push-preview: ${{ inputs.push-preview }}
+          package-filter: ${{ inputs.package-filter }}
           version: ${{ needs.versioning.outputs.version }}
           dotnet-test-args: --maxcpucount:1 #Note: disable parallel test execution due to InlineData and Redis ClearOnStartup property
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,13 @@ on:
           - Release
           - Debug
       push-preview:
-        type: string
+        type: boolean
         description: Push a pre-release NuGet package from a non-default branch?
-        required: true
-        default: "false"
+        default: false
       execute-tests:
-        type: string
+        type: boolean
         description: Execute unit tests?
-        required: false
-        default: "true"
+        default: true
       package-filter:
         type: string
         description: Comma-separated package ID prefixes to push e.g. CasCap.Common.Caching

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageProjectUrl>https://github.com/f2calv/CasCap.Common</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -51,6 +52,7 @@
 
   <ItemGroup>
     <None Include="..\..\icon.png" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" Condition="Exists('README.md')"/>
   </ItemGroup>
 
 </Project>

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -4,8 +4,9 @@ branches:
     regex: ^main$
     label: ''
   feature:
-    regex: ^features?[/-]
-    label: useBranchName
+    mode: ContinuousDelivery
+    regex: ^(features?|f2calv|copilot)[/-](?<BranchName>.+)
+    label: '{BranchName}'
   preview:
     regex: ^preview?[/-]
     label: preview-{BranchName}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 [cascap.common.extensions.diagnostics.healthchecks-url]: https://nuget.org/packages/CasCap.Common.Extensions.Diagnostics.HealthChecks
 [cascap.common.logging-badge]: https://img.shields.io/nuget/v/CasCap.Common.Logging?color=blue
 [cascap.common.logging-url]: https://nuget.org/packages/CasCap.Common.Logging
+[cascap.common.logging.serilog-badge]: https://img.shields.io/nuget/v/CasCap.Common.Logging.Serilog?color=blue
+[cascap.common.logging.serilog-url]: https://nuget.org/packages/CasCap.Common.Logging.Serilog
 [cascap.common.net-badge]: https://img.shields.io/nuget/v/CasCap.Common.Net?color=blue
 [cascap.common.net-url]: https://nuget.org/packages/CasCap.Common.Net
 [cascap.common.Serialization.json-badge]: https://img.shields.io/nuget/v/CasCap.Common.Serialization.Json?color=blue
@@ -25,7 +27,7 @@
 
 ![CI](https://github.com/f2calv/CasCap.Common/actions/workflows/ci.yml/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/f2calv/CasCap.Common/badge.svg?branch=main)](https://coveralls.io/github/f2calv/CasCap.Common?branch=main) [![SonarCloud Coverage](https://sonarcloud.io/api/project_badges/measure?project=f2calv_CasCap.Common&metric=code_smells)](https://sonarcloud.io/component_measures/metric/code_smells/list?id=f2calv_CasCap.Common)
 
-A .NET class library repository containing 11 NuGet packages with helper functions, extensions, utilities, and abstract classes for .NET applications.
+A .NET class library repository containing 12 NuGet packages with helper functions, extensions, utilities, and abstract classes for .NET applications.
 
 | Library                                           | Package                                                                                                |
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
@@ -35,6 +37,7 @@ A .NET class library repository containing 11 NuGet packages with helper functio
 | CasCap.Common.Extensions                          | [![Nuget][cascap.common.extensions-badge]][cascap.common.extensions-url]                               |
 | CasCap.Common.Extensions.Diagnostics.HealthChecks | [![Nuget][cascap.common.extensions.diagnostics.healthchecks-badge]][cascap.common.extensions.diagnostics.healthchecks-url] |
 | CasCap.Common.Logging                             | [![Nuget][cascap.common.logging-badge]][cascap.common.logging-url]                                     |
+| CasCap.Common.Logging.Serilog                     | [![Nuget][cascap.common.logging.serilog-badge]][cascap.common.logging.serilog-url]                     |
 | CasCap.Common.Net                                 | [![Nuget][cascap.common.net-badge]][cascap.common.net-url]                                             |
 | CasCap.Common.Serialization.Json                  | [![Nuget][cascap.common.Serialization.json-badge]][cascap.common.Serialization.json-url]               |
 | CasCap.Common.Serialization.MessagePack           | [![Nuget][cascap.common.Serialization.messagepack-badge]][cascap.common.Serialization.messagepack-url] |
@@ -45,12 +48,13 @@ A .NET class library repository containing 11 NuGet packages with helper functio
 
 | Library | Description | Targets | Packable |
 | ------- | ----------- | ------- | -------- |
-| [**CasCap.Common.Abstractions**](src/CasCap.Common.Abstractions/README.md) | Core interface definitions (`IAppConfig`, `IFeature<T>`, `ILocalCache`, `IEventSink<T>`) | netstandard2.0; net8.0; net9.0; net10.0 | ✅ |
+| [**CasCap.Common.Abstractions**](src/CasCap.Common.Abstractions/README.md) | Core interface definitions (`IAppConfig`, `IFeature<T>`, `ILocalCache`, `IEventSink<T>`, `INotifier`) | netstandard2.0; net8.0; net9.0; net10.0 | ✅ |
 | [**CasCap.Common.Caching**](src/CasCap.Common.Caching/README.md) | Distributed caching (cache-aside pattern) with Memory/Disk local cache and Redis remote cache | netstandard2.0; net8.0; net9.0; net10.0 | ✅ |
 | [**CasCap.Common.Configuration**](src/CasCap.Common.Configuration/README.md) | Configuration bootstrapping — standard `IConfiguration` pipeline, Azure Key Vault, and validated `IOptions<T>` binding | netstandard2.0; net8.0; net9.0; net10.0 | ✅ |
 | [**CasCap.Common.Extensions**](src/CasCap.Common.Extensions/README.md) | Common extension methods and helper utilities | netstandard2.0; net8.0; net9.0; net10.0 | ✅ |
 | [**CasCap.Common.Extensions.Diagnostics.HealthChecks**](src/CasCap.Common.Extensions.Diagnostics.HealthChecks/README.md) | Custom health check extensions | netstandard2.0; net8.0; net9.0; net10.0 | ✅ |
 | [**CasCap.Common.Logging**](src/CasCap.Common.Logging/README.md) | Static logging abstraction via `ApplicationLogging` | netstandard2.0; net8.0; net9.0; net10.0 | ✅ |
+| [**CasCap.Common.Logging.Serilog**](src/CasCap.Common.Logging.Serilog/README.md) | Reusable Serilog configuration with standard enrichers, console sink, and health-check filtering | net8.0; net9.0; net10.0 | ✅ |
 | [**CasCap.Common.Net**](src/CasCap.Common.Net/README.md) | `HttpClientBase` abstract class for HTTP client wrappers (net8.0+ only via `#if`) | netstandard2.0; net8.0; net9.0; net10.0 | ✅ |
 | [**CasCap.Common.Serialization.Json**](src/CasCap.Common.Serialization.Json/README.md) | System.Text.Json serialization helpers | netstandard2.0; net8.0; net9.0; net10.0 | ✅ |
 | [**CasCap.Common.Serialization.MessagePack**](src/CasCap.Common.Serialization.MessagePack/README.md) | MessagePack serialization helpers | netstandard2.0; net8.0; net9.0; net10.0 | ✅ |
@@ -73,6 +77,7 @@ Project reference relationships between libraries (NuGet-only dependencies omitt
 ```mermaid
 graph TD
     Logging[CasCap.Common.Logging]
+    LoggingSerilog[CasCap.Common.Logging.Serilog]
     Abstractions[CasCap.Common.Abstractions]
     Extensions[CasCap.Common.Extensions]
     Configuration[CasCap.Common.Configuration]
@@ -85,6 +90,7 @@ graph TD
     Testing[CasCap.Common.Testing]
 
     Extensions --> Logging
+    LoggingSerilog --> Logging
     Configuration --> Abstractions
     Configuration --> Logging
     SerJson --> Extensions
@@ -92,6 +98,7 @@ graph TD
     SerMsgPack --> Logging
     Net --> SerJson
     Net --> Logging
+    HealthChecks --> Extensions
     HealthChecks --> Logging
     Testing --> Logging
     Services --> Abstractions

--- a/src/CasCap.Common.Abstractions/Abstractions/INotifier.cs
+++ b/src/CasCap.Common.Abstractions/Abstractions/INotifier.cs
@@ -33,4 +33,21 @@ public interface INotifier
     /// <param name="account">The account identifier.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task<INotificationGroup[]?> ListGroupsAsync(string account, CancellationToken cancellationToken = default);
+
+    ///// <summary>
+    ///// Shows a typing indicator to the specified recipient, signalling that the bot is
+    ///// composing a response.
+    ///// </summary>
+    ///// <param name="account">The sender account identifier.</param>
+    ///// <param name="recipient">The recipient identifier (phone number or group ID).</param>
+    ///// <param name="cancellationToken">Cancellation token.</param>
+    //Task<bool> ShowTypingIndicatorAsync(string account, string recipient, CancellationToken cancellationToken = default);
+
+    ///// <summary>
+    ///// Hides the typing indicator for the specified recipient.
+    ///// </summary>
+    ///// <param name="account">The sender account identifier.</param>
+    ///// <param name="recipient">The recipient identifier (phone number or group ID).</param>
+    ///// <param name="cancellationToken">Cancellation token.</param>
+    //Task<bool> HideTypingIndicatorAsync(string account, string recipient, CancellationToken cancellationToken = default);
 }

--- a/src/CasCap.Common.Abstractions/Abstractions/INotifier.cs
+++ b/src/CasCap.Common.Abstractions/Abstractions/INotifier.cs
@@ -34,20 +34,30 @@ public interface INotifier
     /// <param name="cancellationToken">Cancellation token.</param>
     Task<INotificationGroup[]?> ListGroupsAsync(string account, CancellationToken cancellationToken = default);
 
-    ///// <summary>
-    ///// Shows a typing indicator to the specified recipient, signalling that the bot is
-    ///// composing a response.
-    ///// </summary>
-    ///// <param name="account">The sender account identifier.</param>
-    ///// <param name="recipient">The recipient identifier (phone number or group ID).</param>
-    ///// <param name="cancellationToken">Cancellation token.</param>
-    //Task<bool> ShowTypingIndicatorAsync(string account, string recipient, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Signals the recipient that the bot is actively processing a request.
+    /// </summary>
+    /// <param name="account">The sender account identifier.</param>
+    /// <param name="recipient">The recipient identifier (phone number or group ID).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<bool> StartProcessingAsync(string account, string recipient, CancellationToken cancellationToken = default);
 
-    ///// <summary>
-    ///// Hides the typing indicator for the specified recipient.
-    ///// </summary>
-    ///// <param name="account">The sender account identifier.</param>
-    ///// <param name="recipient">The recipient identifier (phone number or group ID).</param>
-    ///// <param name="cancellationToken">Cancellation token.</param>
-    //Task<bool> HideTypingIndicatorAsync(string account, string recipient, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Signals the recipient that the bot has finished processing.
+    /// </summary>
+    /// <param name="account">The sender account identifier.</param>
+    /// <param name="recipient">The recipient identifier (phone number or group ID).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<bool> StopProcessingAsync(string account, string recipient, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sends a progress-update indicator (e.g. an emoji reaction) to a specific message.
+    /// </summary>
+    /// <param name="account">The sender account identifier.</param>
+    /// <param name="recipient">The recipient identifier (phone number or group ID).</param>
+    /// <param name="reaction">The reaction emoji.</param>
+    /// <param name="targetAuthor">The author of the message being reacted to.</param>
+    /// <param name="timestamp">The timestamp of the target message.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<bool> SendProgressUpdateAsync(string account, string recipient, string reaction, string targetAuthor, long timestamp, CancellationToken cancellationToken = default);
 }

--- a/src/CasCap.Common.Abstractions/Abstractions/IReceivedNotification.cs
+++ b/src/CasCap.Common.Abstractions/Abstractions/IReceivedNotification.cs
@@ -27,6 +27,11 @@ public interface IReceivedNotification
     bool HasContent { get; }
 
     /// <summary>
+    /// The timestamp of the message as assigned by the sender, or <see langword="null"/> if unavailable.
+    /// </summary>
+    long? Timestamp { get; }
+
+    /// <summary>
     /// Attachments included with the notification, or <see langword="null"/> if none are present.
     /// </summary>
     IReadOnlyList<INotificationAttachment>? Attachments { get; }

--- a/src/CasCap.Common.Abstractions/README.md
+++ b/src/CasCap.Common.Abstractions/README.md
@@ -18,6 +18,12 @@ This library contains no concrete implementations — only interfaces and abstra
 | `IEventSink<T>` | Generic event sink contract. Domain events are fanned out to every registered `IEventSink<T>` implementation in parallel |
 | `ILocalCache` | Abstraction for an in-process cache provider supporting `Get`, `Set`, `Delete`, and `DeleteAll` |
 | `IMyBlob` | Represents a blob with associated metadata (`bytes`, `DateCreatedUtc`, `BlobName`, `SizeInBytes`, `HasImage`) |
+| `INotifier` | Abstracts a notification service capable of sending and receiving messages with optional attachment support |
+| `INotificationMessage` | Represents an outgoing notification message (text, sender, recipients, attachments) |
+| `INotificationAttachment` | Metadata for an attachment received as part of a notification (`Id`, `ContentType`) |
+| `INotificationGroup` | Represents a named group in a notification service (`Id`, `Name`, members) |
+| `INotificationResponse` | Response returned after sending a notification (`Timestamp`) |
+| `IReceivedNotification` | Represents a notification received from an external messaging service (`Sender`, `GroupId`, `Message`, attachments) |
 
 ### `IEventSink<T>` Contract
 

--- a/src/CasCap.Common.Extensions.Diagnostics.HealthChecks/README.md
+++ b/src/CasCap.Common.Extensions.Diagnostics.HealthChecks/README.md
@@ -26,4 +26,5 @@ Provides `HttpEndpointCheckBase`, an abstract `IHealthCheck` that simplifies wri
 
 | Project | Purpose |
 | --- | --- |
+| `CasCap.Common.Extensions` | General-purpose helper utilities |
 | `CasCap.Common.Logging` | `ApplicationLogging` static logger factory |

--- a/src/CasCap.Common.Net/Extensions/NetExtensions.cs
+++ b/src/CasCap.Common.Net/Extensions/NetExtensions.cs
@@ -55,6 +55,31 @@ public static class NetExtensions
         headers.Add(name, value);
     }
 
+    /// <summary>
+    /// Sets the <c>Authorization</c> header to HTTP Basic credentials derived from the
+    /// supplied <paramref name="username"/> and <paramref name="password"/>.
+    /// </summary>
+    /// <param name="client">The <see cref="HttpClient"/> to configure.</param>
+    /// <param name="username">The Basic authentication username.</param>
+    /// <param name="password">The Basic authentication password.</param>
+    public static void SetBasicAuth(this HttpClient client, string username, string password)
+    {
+        var base64 = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{username}:{password}"));
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", base64);
+    }
+
+    /// <summary>
+    /// Returns the full HTTP Basic <c>Authorization</c> header value (e.g. <c>"Basic dXNlcjpwYXNz"</c>)
+    /// suitable for use with SignalR hub connections or other HTTP clients.
+    /// </summary>
+    /// <param name="username">The Basic authentication username.</param>
+    /// <param name="password">The Basic authentication password.</param>
+    public static string GetBasicAuthHeaderValue(string username, string password)
+    {
+        var base64 = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{username}:{password}"));
+        return $"Basic {base64}";
+    }
+
     //public static async Task<T?> ReadAsJsonAsync<T>(this HttpContent content)//for .NET Standard compatibility
     //{
     //    var json = await content.ReadAsStringAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Commits

| Hash | Message | Author | Date |
| --- | --- | --- | --- |
| `6140715` | update readmes | Alex Vincent | 2026-04-02 |
| `31372e7` | centralize basic auth setup | Alex Vincent | 2026-04-02 |
| `6f1b2f9` | add readme to pkgs | Alex Vincent | 2026-04-02 |
| `4a2370f` | tidy workflow | Alex Vincent | 2026-04-02 |
| `2801a05` | tweak ci | Alex Vincent | 2026-04-02 |
| `10e0669` | expand INotifier | Alex Vincent | 2026-04-02 |
| `6584c73` | debugging | Alex Vincent | 2026-04-01 |
| `3bc159a` | fix versioning | Alex Vincent | 2026-04-01 |
| `a42fcd5` | bug fixes + docs | Alex Vincent | 2026-04-01 |

## Files Changed

| File | Change | Insertions | Deletions |
| --- | --- | --- | --- |
| `.github/copilot-instructions.md` | Modified | 1 | 1 |
| `.github/workflows/ci.yml` | Modified | 14 | 3 |
| `Directory.Build.props` | Modified | 2 | 0 |
| `GitVersion.yml` | Modified | 3 | 2 |
| `README.md` | Modified | 9 | 2 |
| `src/CasCap.Common.Abstractions/Abstractions/INotifier.cs` | Modified | 27 | 0 |
| `src/CasCap.Common.Abstractions/Abstractions/IReceivedNotification.cs` | Modified | 5 | 0 |
| `src/CasCap.Common.Abstractions/README.md` | Modified | 6 | 0 |
| `src/CasCap.Common.Extensions.Diagnostics.HealthChecks/README.md` | Modified | 1 | 0 |
| `src/CasCap.Common.Net/Extensions/NetExtensions.cs` | Modified | 25 | 0 |

_10 files changed, 93 insertions, 8 deletions._

## Change Details

### 1. `INotifier` — expanded interface (`CasCap.Common.Abstractions`)

The `INotifier` interface was significantly expanded from a simple send-only contract to a full bidirectional notification abstraction. New methods added:

1. `ReceiveAsync(account)` — polls for pending incoming notifications, returning `IReceivedNotification[]`.
2. `GetAttachmentAsync(attachmentId)` — downloads raw attachment bytes by ID.
3. `ListGroupsAsync(account)` — lists available messaging groups for an account.
4. `StartProcessingAsync(account, recipient)` — signals the recipient that the bot is actively processing (typing indicator).
5. `StopProcessingAsync(account, recipient)` — signals the recipient that processing has finished.
6. `SendProgressUpdateAsync(account, recipient, reaction, targetAuthor, timestamp)` — sends a reaction/emoji progress indicator on a specific message.

### 2. `IReceivedNotification` — new properties

Added `Timestamp` (`long?`) and `Attachments` (`IReadOnlyList<INotificationAttachment>?`) properties to the received notification interface, enabling attachment-aware message processing.

### 3. Basic auth helpers (`CasCap.Common.Net`)

Two new utility methods added to `NetExtensions`:

1. `HttpClient.SetBasicAuth(username, password)` — sets the `Authorization` header to HTTP Basic credentials on an `HttpClient`.
2. `GetBasicAuthHeaderValue(username, password)` — returns the full `Basic <base64>` header value string for use with SignalR hub connections or other HTTP clients.

### 4. CI workflow improvements (`.github/workflows/ci.yml`)

1. Added `package-filter` string input to `workflow_dispatch` for selectively pushing specific NuGet packages by prefix.
2. Split versioning into a separate `versioning` job using `gha-release-versioning.yml` reusable workflow.
3. Added a `release` job that conditionally creates a tag/release only when one doesn't already exist and the branch is the default branch (or `push-preview` is enabled).
4. Passes `version` output from the versioning job into the build step.

### 5. GitVersion configuration

1. Changed feature branch regex to also match `copilot/` prefixed branches: `^(features?|f2calv|copilot)[/-]`.
2. Added explicit `mode: ContinuousDelivery` for feature branches.

### 6. Directory.Build.props

1. Added `<PackageReadmeFile>README.md</PackageReadmeFile>` to include README.md files in NuGet packages.
2. Added corresponding `<None Include="README.md" Pack="true" PackagePath="\" />` item with existence check.

### 7. README updates

1. **Root `README.md`** — updated the Libraries table to include the `INotifier` interface in the Abstractions library description, refreshed target framework list.
2. **`CasCap.Common.Abstractions/README.md`** — documented the expanded `INotifier` interface and its new methods.
3. **`CasCap.Common.Extensions.Diagnostics.HealthChecks/README.md`** — minor documentation update.
