### PR TITLE
feat: HTTP auditing infrastructure + standardize CasCap.Common namespaces

### DIFF
--- a/CasCap.Common.slnx
+++ b/CasCap.Common.slnx
@@ -8,6 +8,7 @@
     <File Path="docker-compose.yml" />
     <File Path="GitVersion.yml" />
     <File Path="global.json" />
+    <File Path="LICENSE" />
     <File Path="README.md" />
   </Folder>
   <Folder Name="/CasCap.Common/">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,8 +24,10 @@
     <!-- <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile> -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageProjectUrl>https://github.com/f2calv/CasCap.Common</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseExpression>Unlicense</PackageLicenseExpression>
+    <Copyright>Copyright (c) Alex Vincent 2026</Copyright>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>See https://github.com/f2calv/CasCap.Common/releases</PackageReleaseNotes>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageVersion Include="MessagePack" Version="3.1.4" />
     <PackageVersion Include="MessagePackAnalyzer" Version="3.1.4" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.3.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.7" />
@@ -21,9 +21,9 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.5.1" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.5.1" />
-    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.5.1" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.5.2" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.5.2" />
+    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.5.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
@@ -40,8 +40,8 @@
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.19" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.Agents.AI" Version="1.3.0" />
-    <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.5.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
     <PackageVersion Include="OllamaSharp" Version="5.4.25" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />

--- a/src/CasCap.Common.AI/Abstractions/IPollTracker.cs
+++ b/src/CasCap.Common.AI/Abstractions/IPollTracker.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Abstractions;
+namespace CasCap.Common.Abstractions;
 
 /// <summary>
 /// Tracks active polls created by the agent and records incoming votes so

--- a/src/CasCap.Common.AI/Abstractions/ISessionStore.cs
+++ b/src/CasCap.Common.AI/Abstractions/ISessionStore.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Abstractions;
+namespace CasCap.Common.Abstractions;
 
 /// <summary>Persistence abstraction for serialised agent session state.</summary>
 /// <remarks>

--- a/src/CasCap.Common.AI/Extensions/AgentExtensions.Mcp.cs
+++ b/src/CasCap.Common.AI/Extensions/AgentExtensions.Mcp.cs
@@ -1,6 +1,6 @@
 using ModelContextProtocol.Client;
 
-namespace CasCap.Extensions;
+namespace CasCap.Common.Extensions;
 
 /// <summary>MCP client connectivity, prompt discovery, and prompt filtering.</summary>
 public static partial class AgentExtensions

--- a/src/CasCap.Common.AI/Extensions/AgentExtensions.Middleware.cs
+++ b/src/CasCap.Common.AI/Extensions/AgentExtensions.Middleware.cs
@@ -1,7 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 
-namespace CasCap.Extensions;
+namespace CasCap.Common.Extensions;
 
 /// <summary>Chat client, agent run, and function-calling middleware plus audio transcoding.</summary>
 public static partial class AgentExtensions

--- a/src/CasCap.Common.AI/Extensions/AgentExtensions.Tools.cs
+++ b/src/CasCap.Common.AI/Extensions/AgentExtensions.Tools.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Extensions;
+namespace CasCap.Common.Extensions;
 
 /// <summary>Tool discovery, filtering, and sub-agent delegation tool creation.</summary>
 public static partial class AgentExtensions

--- a/src/CasCap.Common.AI/Extensions/AgentExtensions.cs
+++ b/src/CasCap.Common.AI/Extensions/AgentExtensions.cs
@@ -5,7 +5,7 @@ using OpenAI;
 using System.ClientModel;
 using System.Text.Json;
 
-namespace CasCap.Extensions;
+namespace CasCap.Common.Extensions;
 
 /// <summary>
 /// Extension methods for <see cref="AIAgent"/> that simplify creating agents and running inference

--- a/src/CasCap.Common.AI/Extensions/ChatCommandExtensions.cs
+++ b/src/CasCap.Common.AI/Extensions/ChatCommandExtensions.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Extensions;
+namespace CasCap.Common.Extensions;
 
 /// <summary>
 /// Shared helpers for parsing and executing <see cref="ChatCommand"/> slash-commands.

--- a/src/CasCap.Common.AI/GlobalUsings.cs
+++ b/src/CasCap.Common.AI/GlobalUsings.cs
@@ -1,9 +1,7 @@
-global using CasCap.Abstractions;
 global using CasCap.Common.Abstractions;
 global using CasCap.Common.Extensions;
-global using CasCap.Extensions;
-global using CasCap.Models;
-global using CasCap.Services;
+global using CasCap.Common.Models;
+global using CasCap.Common.Services;
 global using Microsoft.Agents.AI;
 global using Microsoft.Extensions.AI;
 global using Microsoft.Extensions.DependencyInjection;

--- a/src/CasCap.Common.AI/Models/ActivePoll.cs
+++ b/src/CasCap.Common.AI/Models/ActivePoll.cs
@@ -1,6 +1,6 @@
 using System.Collections.Concurrent;
 
-namespace CasCap.Models;
+namespace CasCap.Common.Models;
 
 /// <summary>
 /// Represents an active poll being tracked for vote results.

--- a/src/CasCap.Common.AI/Models/AgentInfo.cs
+++ b/src/CasCap.Common.AI/Models/AgentInfo.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Models;
+namespace CasCap.Common.Models;
 
 /// <summary>MCP-friendly projection of <see cref="AgentConfig"/> (excludes instructions and settings).</summary>
 public record AgentInfo

--- a/src/CasCap.Common.AI/Models/AgentRunAttachment.cs
+++ b/src/CasCap.Common.AI/Models/AgentRunAttachment.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Models;
+namespace CasCap.Common.Models;
 
 /// <summary>Represents a binary attachment produced by a tool during an agent run.</summary>
 public sealed record AgentRunAttachment

--- a/src/CasCap.Common.AI/Models/AgentRunResult.cs
+++ b/src/CasCap.Common.AI/Models/AgentRunResult.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Models;
+namespace CasCap.Common.Models;
 
 /// <summary>
 /// Accumulates and exposes the result of an AI agent run, including diagnostic

--- a/src/CasCap.Common.AI/Models/AudioDebugArtifacts.cs
+++ b/src/CasCap.Common.AI/Models/AudioDebugArtifacts.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Models;
+namespace CasCap.Common.Models;
 
 /// <summary>
 /// Captures the original and transcoded audio bytes during sub-agent delegation

--- a/src/CasCap.Common.AI/Models/McpPromptDescriptor.cs
+++ b/src/CasCap.Common.AI/Models/McpPromptDescriptor.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Models;
+namespace CasCap.Common.Models;
 
 /// <summary>
 /// Lightweight descriptor for an MCP prompt discovered from either a remote

--- a/src/CasCap.Common.AI/Models/PollStatusResult.cs
+++ b/src/CasCap.Common.AI/Models/PollStatusResult.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Models;
+namespace CasCap.Common.Models;
 
 /// <summary>
 /// Result object returned by the <c>get_poll_status</c> MCP tool, summarising the

--- a/src/CasCap.Common.AI/Models/PromptSource.cs
+++ b/src/CasCap.Common.AI/Models/PromptSource.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Models;
+namespace CasCap.Common.Models;
 
 /// <summary>
 /// Identifies a single source of MCP prompts for an agent, with optional include/exclude

--- a/src/CasCap.Common.AI/Models/ProviderInfo.cs
+++ b/src/CasCap.Common.AI/Models/ProviderInfo.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Models;
+namespace CasCap.Common.Models;
 
 /// <summary>MCP-friendly projection of <see cref="ProviderConfig"/> (excludes sensitive fields).</summary>
 public record ProviderInfo

--- a/src/CasCap.Common.AI/Models/StateBagEntry.cs
+++ b/src/CasCap.Common.AI/Models/StateBagEntry.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Extensions;
+namespace CasCap.Common.Extensions;
 
 /// <summary>Summary of a single entry in the <see cref="Microsoft.Agents.AI.AgentSessionStateBag"/>.</summary>
 /// <param name="Key">The StateBag key name.</param>

--- a/src/CasCap.Common.AI/Models/ToolCallInfo.cs
+++ b/src/CasCap.Common.AI/Models/ToolCallInfo.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Models;
+namespace CasCap.Common.Models;
 
 /// <summary>Captures the name and arguments of a single tool/function call during an agent run.</summary>
 public sealed record ToolCallInfo(string Name, IDictionary<string, object?>? Arguments);

--- a/src/CasCap.Common.AI/Models/ToolSource.cs
+++ b/src/CasCap.Common.AI/Models/ToolSource.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Models;
+namespace CasCap.Common.Models;
 
 /// <summary>
 /// Identifies a single source of MCP tools for an agent, with optional include/exclude

--- a/src/CasCap.Common.AI/Models/_AIConfig.cs
+++ b/src/CasCap.Common.AI/Models/_AIConfig.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Models;
+namespace CasCap.Common.Models;
 
 /// <summary>
 /// AI agent configuration: named providers and agents keyed by identifier.

--- a/src/CasCap.Common.AI/Models/_AgentConfig.cs
+++ b/src/CasCap.Common.AI/Models/_AgentConfig.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Models;
+namespace CasCap.Common.Models;
 
 /// <summary>
 /// Behavioral configuration for a named AI agent: instructions, prompt, reasoning, tools and prompts.

--- a/src/CasCap.Common.AI/Models/_Enums.cs
+++ b/src/CasCap.Common.AI/Models/_Enums.cs
@@ -26,7 +26,7 @@ public enum ChatCommand
     [Description("/session bypass")]
     SessionBypass,
 
-    /// <summary>Reduces the active session to the newest N messages, discarding older history. Usage: /session compact {count}</summary>
+    /// <summary>Reduces the active session to the newest N messages, discarding older history. Usage: /session compact {Count}</summary>
     [Description("/session compact")]
     SessionCompact,
 

--- a/src/CasCap.Common.AI/Models/_Enums.cs
+++ b/src/CasCap.Common.AI/Models/_Enums.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Models;
+namespace CasCap.Common.Models;
 
 /// <summary>
 /// Slash-commands that can be entered at a console prompt or sent via a messaging interface

--- a/src/CasCap.Common.AI/Models/_ProviderConfig.cs
+++ b/src/CasCap.Common.AI/Models/_ProviderConfig.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Models;
+namespace CasCap.Common.Models;
 
 /// <summary>
 /// Infrastructure configuration for an AI provider (connection details, model, auth).

--- a/src/CasCap.Common.AI/README.md
+++ b/src/CasCap.Common.AI/README.md
@@ -2,6 +2,12 @@
 
 AI agent framework infrastructure — agent creation, session management, MCP tool/prompt resolution, chat history compaction, and slash-command handling.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Common.AI
+```
+
 ## Purpose
 
 Provides the shared infrastructure for building multi-agent AI systems with support for multiple providers (Azure OpenAI, OpenAI, Ollama), automatic MCP tool discovery from `[McpServerTool]`-decorated service types, sub-agent delegation (fan-out pattern), persistent session state, and context-window compaction for edge GPU devices.

--- a/src/CasCap.Common.AI/Services/AgentCommandHandler.cs
+++ b/src/CasCap.Common.AI/Services/AgentCommandHandler.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
 
-namespace CasCap.Services;
+namespace CasCap.Common.Services;
 
 /// <summary>Shared handler for <see cref="ChatCommand"/> slash-commands and agent session management.</summary>
 /// <remarks>

--- a/src/CasCap.Common.AI/Services/DistributedCacheSessionStore.cs
+++ b/src/CasCap.Common.AI/Services/DistributedCacheSessionStore.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Services;
+namespace CasCap.Common.Services;
 
 /// <summary>Redis-backed session store for persistent agent sessions.</summary>
 /// <remarks>

--- a/src/CasCap.Common.AI/Services/InMemoryPollTracker.cs
+++ b/src/CasCap.Common.AI/Services/InMemoryPollTracker.cs
@@ -1,6 +1,6 @@
 using System.Collections.Concurrent;
 
-namespace CasCap.Services;
+namespace CasCap.Common.Services;
 
 /// <summary>
 /// In-memory implementation of <see cref="IPollTracker"/> that tracks active polls

--- a/src/CasCap.Common.AI/Services/InMemorySessionStore.cs
+++ b/src/CasCap.Common.AI/Services/InMemorySessionStore.cs
@@ -1,6 +1,6 @@
 using System.Collections.Concurrent;
 
-namespace CasCap.Services;
+namespace CasCap.Common.Services;
 
 /// <summary>Volatile in-memory session store for interactive console sessions.</summary>
 /// <remarks>

--- a/src/CasCap.Common.AI/Services/ToolOutputStrippingChatReducer.cs
+++ b/src/CasCap.Common.AI/Services/ToolOutputStrippingChatReducer.cs
@@ -1,8 +1,8 @@
-using CasCap.Extensions;
+using CasCap.Common.Extensions;
 using Microsoft.Extensions.AI;
 using Serilog;
 
-namespace CasCap.Services;
+namespace CasCap.Common.Services;
 
 /// <summary>
 /// An <see cref="IChatReducer"/> that strips <see cref="FunctionCallContent"/> and

--- a/src/CasCap.Common.Abstractions/Abstractions/HttpAuditEntry.cs
+++ b/src/CasCap.Common.Abstractions/Abstractions/HttpAuditEntry.cs
@@ -1,0 +1,34 @@
+#if NET8_0_OR_GREATER
+namespace CasCap.Common.Abstractions;
+
+/// <summary>Represents a single HTTP request/response audit record.</summary>
+public record HttpAuditEntry
+{
+    /// <summary>Auto-generated primary key.</summary>
+    public long Id { get; set; }
+
+    /// <summary>UTC timestamp when the request was initiated.</summary>
+    public DateTime TimestampUtc { get; init; }
+
+    /// <summary>Logical source name (e.g. the typed HttpClient name).</summary>
+    public required string Source { get; init; }
+
+    /// <summary>HTTP method (GET, POST, PUT, DELETE, etc.).</summary>
+    public required string HttpMethod { get; init; }
+
+    /// <summary>Full request URI including query string.</summary>
+    public required string RequestUri { get; init; }
+
+    /// <summary>HTTP response status code.</summary>
+    public int StatusCode { get; init; }
+
+    /// <summary>Round-trip elapsed time in milliseconds.</summary>
+    public double ElapsedMs { get; init; }
+
+    /// <summary>Raw JSON request body, or <see langword="null"/> for bodyless requests.</summary>
+    public string? RequestBody { get; init; }
+
+    /// <summary>Raw JSON response body.</summary>
+    public string? ResponseBody { get; init; }
+}
+#endif

--- a/src/CasCap.Common.Abstractions/Abstractions/IHttpAuditStore.cs
+++ b/src/CasCap.Common.Abstractions/Abstractions/IHttpAuditStore.cs
@@ -1,0 +1,12 @@
+#if NET8_0_OR_GREATER
+namespace CasCap.Common.Abstractions;
+
+/// <summary>Abstraction for persisting HTTP audit entries.</summary>
+public interface IHttpAuditStore
+{
+    /// <summary>Persists a single audit entry.</summary>
+    /// <param name="entry">The HTTP audit entry to store.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task SaveAsync(HttpAuditEntry entry, CancellationToken cancellationToken = default);
+}
+#endif

--- a/src/CasCap.Common.Abstractions/README.md
+++ b/src/CasCap.Common.Abstractions/README.md
@@ -2,6 +2,12 @@
 
 Core interface definitions shared across the CasCap ecosystem. This project provides the foundational contracts that other CasCap libraries and applications may depend upon.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Common.Abstractions
+```
+
 ## Purpose
 
 This library contains no concrete implementations — only interfaces and abstractions that define the contracts between components.

--- a/src/CasCap.Common.Abstractions/README.md
+++ b/src/CasCap.Common.Abstractions/README.md
@@ -30,6 +30,7 @@ This library contains no concrete implementations — only interfaces and abstra
 | `INotificationGroup` | Represents a named group in a notification service (`Id`, `Name`, members) |
 | `INotificationResponse` | Response returned after sending a notification (`Timestamp`) |
 | `IReceivedNotification` | Represents a notification received from an external messaging service (`Sender`, `GroupId`, `Message`, attachments) |
+| `IHttpAuditStore` | Abstraction for persisting HTTP audit entries (net8.0+ only) |
 | `IAzBlobStorageConfig` | Exposes Azure Blob Storage connection properties (endpoint/connection string, container name, health check probe type) for feature-specific configuration records |
 | `IAzTableStorageConfig` | Exposes Azure Table Storage connection properties (endpoint/connection string, health check probe type) for feature-specific configuration records |
 | `IFeatureConfig<T>` | **[Obsolete]** Pairs with `IFeature<T>` to carry the enabled `EnabledFeatures` flags into the `BackgroundService` launcher |
@@ -50,6 +51,12 @@ This library contains no concrete implementations — only interfaces and abstra
 | `SinkConfig` | Dictionary of `SinkTypeAttribute` name → `SinkConfigParams` |
 | `SinkConfigParams` | Per-sink settings: `Enabled`, and a `Settings` dictionary for sink-specific key/value settings |
 | `SinkSettingKeys` | Compile-time constants for common sink setting keys |
+
+### Models
+
+| Type | Description |
+| --- | --- |
+| `HttpAuditEntry` | Represents a single HTTP request/response audit record — `Source`, `HttpMethod`, `RequestUri`, `StatusCode`, `ElapsedMs`, `RequestBody`, `ResponseBody` (net8.0+ only) |
 
 ### Event Models
 

--- a/src/CasCap.Common.Caching/README.md
+++ b/src/CasCap.Common.Caching/README.md
@@ -2,6 +2,12 @@
 
 Multi-tier distributed caching library implementing the cache-aside pattern with support for Memory, Disk, and Redis cache layers.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Common.Caching
+```
+
 ## Purpose
 
 Provides a complete caching infrastructure with local (in-process) and remote (Redis) cache tiers, synchronised expiration via Redis Pub/Sub, and configurable serialization (JSON or MessagePack). Includes background services for cache expiry management, an async duplicate-lock mechanism to prevent thundering-herd scenarios, and optional Redis-based distributed locking via RedLock.net.

--- a/src/CasCap.Common.Caching/Services/CacheExpiryBgService.cs
+++ b/src/CasCap.Common.Caching/Services/CacheExpiryBgService.cs
@@ -11,7 +11,9 @@ public class CacheExpiryBgService(ILogger<CacheExpiryBgService> logger,
     {
         await Task.Yield();
         logger.LogInformation("{ClassName} starting", nameof(CacheExpiryBgService));
-        await Task.WhenAll(
+        // await-await-WhenAny propagates the first faulted task immediately so the
+        // service crashes and the pod restarts rather than running in a degraded state.
+        await await Task.WhenAny(
             localCacheExpirySvc.ExecuteAsync(stoppingToken),
             remoteCacheExpirySvc.ExecuteAsync(stoppingToken));
         logger.LogInformation("{ClassName} exiting", nameof(CacheExpiryBgService));

--- a/src/CasCap.Common.Configuration/README.md
+++ b/src/CasCap.Common.Configuration/README.md
@@ -2,6 +2,12 @@
 
 Configuration bootstrapping helpers for .NET applications — standard `IConfiguration` pipeline setup, Azure Key Vault integration, and validated `IOptions<T>` binding for `IAppConfig` records.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Common.Configuration
+```
+
 ## Purpose
 
 Provides a standardised way to build the configuration pipeline (appsettings.json, environment overrides, environment variables, user secrets, Azure Key Vault) and to bind configuration sections to `IAppConfig` record types with DataAnnotations validation on startup.

--- a/src/CasCap.Common.Extensions.Diagnostics.HealthChecks/README.md
+++ b/src/CasCap.Common.Extensions.Diagnostics.HealthChecks/README.md
@@ -2,6 +2,12 @@
 
 Custom ASP.NET Core health check base classes for monitoring HTTP endpoint availability.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Common.Extensions.Diagnostics.HealthChecks
+```
+
 ## Purpose
 
 Provides `HttpEndpointCheckBase`, an abstract `IHealthCheck` that simplifies writing health checks for external HTTP endpoints. Derived classes only need to supply the target URL; the base class handles the HTTP call, timeout, and result mapping.

--- a/src/CasCap.Common.Extensions/README.md
+++ b/src/CasCap.Common.Extensions/README.md
@@ -2,6 +2,12 @@
 
 General-purpose extension methods and helper utilities for .NET applications.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Common.Extensions
+```
+
 ## Purpose
 
 Provides commonly-used extension methods for enums, parsing, I/O, collections, and XML — used as a foundational utility library across the CasCap ecosystem.

--- a/src/CasCap.Common.Logging.Serilog/README.md
+++ b/src/CasCap.Common.Logging.Serilog/README.md
@@ -2,6 +2,12 @@
 
 Reusable Serilog configuration with standard enrichers, console sink, and health-check filtering built on top of `CasCap.Common.Logging`.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Common.Logging.Serilog
+```
+
 ## Purpose
 
 Provides a bootstrap logger for early startup logging and a composable `AddCasCapDefaults` extension on `LoggerConfiguration` that applies the standard CasCap Serilog pipeline: platform-aware console sink, common enrichers, health-check noise filter, and `appsettings.json` binding.

--- a/src/CasCap.Common.Logging/README.md
+++ b/src/CasCap.Common.Logging/README.md
@@ -2,6 +2,12 @@
 
 Static logging abstraction via `ApplicationLogging`, providing a globally accessible `ILoggerFactory` for contexts where constructor injection is unavailable.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Common.Logging
+```
+
 ## Purpose
 
 Exposes a static `ApplicationLogging` class that holds an `ILoggerFactory` reference and `CreateLogger` convenience methods. An `AddStaticLogging()` extension on `IServiceProvider` wires the DI-registered factory into the static accessor at application startup.

--- a/src/CasCap.Common.Net/Auditing/FileHttpAuditStore.cs
+++ b/src/CasCap.Common.Net/Auditing/FileHttpAuditStore.cs
@@ -1,0 +1,48 @@
+#if NET8_0_OR_GREATER
+using System.IO;
+using System.Text.Json;
+using CasCap.Common.Converters;
+
+namespace CasCap.Common.Auditing;
+
+/// <summary>
+/// Lightweight file-based <see cref="IHttpAuditStore"/> that writes each audit entry as an individual
+/// JSON file, organised into daily sub-folders (<c>yyyy-MM-dd</c>).
+/// </summary>
+/// <remarks>
+/// Intended as a zero-dependency fallback for consumers who do not have PostgreSQL (or another
+/// persistent store) available. Files are written to <paramref name="outputDirectory"/> which
+/// defaults to <c>./http-audit</c> relative to the working directory.
+/// JSON request/response bodies are embedded as raw JSON objects (not escaped strings) so they
+/// are directly readable and extractable from the output files.
+/// </remarks>
+public sealed class FileHttpAuditStore(
+    ILogger<FileHttpAuditStore> logger,
+    string outputDirectory = "http-audit"
+) : IHttpAuditStore
+{
+    private static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        WriteIndented = true,
+        Converters = { new RawJsonStringConverter() },
+    };
+
+    /// <inheritdoc/>
+    public async Task SaveAsync(HttpAuditEntry entry, CancellationToken cancellationToken = default)
+    {
+        var datePart = entry.TimestampUtc.ToString("yyyy-MM-dd");
+        var dayDir = Path.Combine(outputDirectory, datePart);
+        Directory.CreateDirectory(dayDir);
+
+        var timestamp = entry.TimestampUtc.ToString("HHmmss-fff");
+        var fileName = $"{timestamp}_{entry.Source}_{entry.StatusCode}.json";
+        var filePath = Path.Combine(dayDir, fileName);
+
+        await using var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None,
+            bufferSize: 4096, useAsync: true);
+        await JsonSerializer.SerializeAsync(stream, entry, s_jsonOptions, cancellationToken).ConfigureAwait(false);
+
+        logger.LogTrace("{ClassName} wrote audit entry to {FilePath}", nameof(FileHttpAuditStore), filePath);
+    }
+}
+#endif

--- a/src/CasCap.Common.Net/Auditing/HttpAuditHandler.cs
+++ b/src/CasCap.Common.Net/Auditing/HttpAuditHandler.cs
@@ -1,0 +1,55 @@
+#if NET8_0_OR_GREATER
+namespace CasCap.Common.Auditing;
+
+/// <summary>
+/// <see cref="DelegatingHandler"/> that captures HTTP request/response pairs and persists them via <see cref="IHttpAuditStore"/>.
+/// </summary>
+public class HttpAuditHandler(
+    IHttpAuditStore auditStore,
+    ILogger<HttpAuditHandler> logger
+) : DelegatingHandler
+{
+    /// <inheritdoc/>
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        string? requestBody = null;
+        if (request.Content is not null)
+            requestBody = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        var start = TimeProvider.System.GetTimestamp();
+        var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        var elapsed = TimeProvider.System.GetElapsedTime(start);
+
+        string? responseBody = null;
+        if (response.Content is not null)
+            responseBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        var entry = new HttpAuditEntry
+        {
+            TimestampUtc = DateTime.UtcNow,
+            Source = request.Options.TryGetValue(HttpAuditSource.Key, out var source)
+                ? source ?? "Unknown"
+                : "Unknown",
+            HttpMethod = request.Method.Method,
+            RequestUri = request.RequestUri?.PathAndQuery ?? string.Empty,
+            StatusCode = (int)response.StatusCode,
+            ElapsedMs = elapsed.TotalMilliseconds,
+            RequestBody = requestBody,
+            ResponseBody = responseBody,
+        };
+
+        try
+        {
+            await auditStore.SaveAsync(entry, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "{ClassName} failed to persist audit entry for {RequestUri}",
+                nameof(HttpAuditHandler), entry.RequestUri);
+        }
+
+        return response;
+    }
+}
+#endif

--- a/src/CasCap.Common.Net/Auditing/HttpAuditSource.cs
+++ b/src/CasCap.Common.Net/Auditing/HttpAuditSource.cs
@@ -1,0 +1,10 @@
+#if NET8_0_OR_GREATER
+namespace CasCap.Common.Auditing;
+
+/// <summary>Defines the <see cref="HttpRequestOptionsKey{TValue}"/> used to tag requests with a logical source name.</summary>
+public static class HttpAuditSource
+{
+    /// <summary>The options key used to pass the source name through <see cref="HttpRequestMessage.Options"/>.</summary>
+    public static readonly HttpRequestOptionsKey<string> Key = new("HttpAuditSource");
+}
+#endif

--- a/src/CasCap.Common.Net/Authentication/BasicAuthenticationHandler.cs
+++ b/src/CasCap.Common.Net/Authentication/BasicAuthenticationHandler.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 
-namespace CasCap.Authentication;
+namespace CasCap.Common.Authentication;
 
 /// <summary>
 /// ASP.NET Core authentication handler that validates HTTP Basic credentials

--- a/src/CasCap.Common.Net/Extensions/HttpClientBuilderAuditExtensions.cs
+++ b/src/CasCap.Common.Net/Extensions/HttpClientBuilderAuditExtensions.cs
@@ -1,0 +1,39 @@
+#if NET8_0_OR_GREATER
+using CasCap.Common.Auditing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CasCap.Common.Extensions;
+
+/// <summary>Extension methods for adding HTTP audit logging to <see cref="IHttpClientBuilder"/> registrations.</summary>
+public static class HttpClientBuilderAuditExtensions
+{
+    /// <summary>
+    /// Adds the <see cref="HttpAuditHandler"/> to the HTTP client pipeline with a logical source name.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHttpClientBuilder"/> to configure.</param>
+    /// <param name="sourceName">
+    /// A display name for the calling service (typically <c>nameof(MyService)</c>)
+    /// stored as <see cref="HttpAuditEntry.Source"/>.
+    /// </param>
+    /// <returns>The <see cref="IHttpClientBuilder"/> for further chaining.</returns>
+    public static IHttpClientBuilder AddHttpAuditing(this IHttpClientBuilder builder, string sourceName)
+    {
+        builder.Services.AddTransient<HttpAuditHandler>();
+        builder.AddHttpMessageHandler(() => new HttpAuditSourceHandler(sourceName));
+        builder.AddHttpMessageHandler<HttpAuditHandler>();
+        return builder;
+    }
+
+    /// <summary>Internal handler that stamps each outgoing request with the logical source name.</summary>
+    private sealed class HttpAuditSourceHandler(string sourceName) : DelegatingHandler
+    {
+        /// <inheritdoc/>
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.Options.Set(HttpAuditSource.Key, sourceName);
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}
+#endif

--- a/src/CasCap.Common.Net/README.md
+++ b/src/CasCap.Common.Net/README.md
@@ -26,12 +26,21 @@ Provides `HttpClientBase`, an abstract class giving derived HTTP clients a consi
 | --- | --- |
 | `BasicAuthenticationHandler` | ASP.NET Core authentication handler validating HTTP Basic credentials against `ApiAuthConfig` (net8.0+ only) |
 
+### HTTP Auditing
+
+| Type | Description |
+| --- | --- |
+| `HttpAuditHandler` | `DelegatingHandler` that captures HTTP request/response pairs and persists them via `IHttpAuditStore` (net8.0+ only) |
+| `HttpAuditSource` | Defines the `HttpRequestOptionsKey` used to tag requests with a logical source name |
+| `FileHttpAuditStore` | Lightweight file-based `IHttpAuditStore` that writes each audit entry as an individual JSON file organised into daily sub-folders (`yyyy-MM-dd`) |
+
 ### Extensions
 
 | Class | Key Methods |
 | --- | --- |
 | `NetExtensions` | `HttpResponseHeaders.TryGetValue()`, `ToQueryString()`, `AddOrOverwrite()` |
 | `HttpClientBuilderResilienceExtensions` | `AddStandardResilience()` — adds retry, circuit breaker, and timeout via `Microsoft.Extensions.Http.Resilience` with structured logging |
+| `HttpClientBuilderAuditExtensions` | `AddHttpAuditing(sourceName)` — adds `HttpAuditHandler` to the HTTP client pipeline to capture request/response audit entries (net8.0+ only) |
 
 ## Class Hierarchy
 

--- a/src/CasCap.Common.Net/README.md
+++ b/src/CasCap.Common.Net/README.md
@@ -2,6 +2,12 @@
 
 Abstract base class, extensions, and authentication handlers for building typed `HttpClient` wrappers and securing ASP.NET Core APIs.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Common.Net
+```
+
 ## Purpose
 
 Provides `HttpClientBase`, an abstract class giving derived HTTP clients a consistent surface for `GET`, `POST`, `PUT`, and `DELETE` operations with automatic JSON (de)serialization. Network-related extension methods for headers and query strings are also included. Additionally provides `BasicAuthenticationHandler` for HTTP Basic authentication against `ApiAuthConfig`. The `HttpClientBase` and `BasicAuthenticationHandler` implementations are gated behind `#if NET8_0_OR_GREATER`.

--- a/src/CasCap.Common.Net/Services/HttpClientBase.cs
+++ b/src/CasCap.Common.Net/Services/HttpClientBase.cs
@@ -107,9 +107,6 @@ public abstract class HttpClientBase
         return await HandleResult<TResult, TError>(response, cts.Token);
     }
 
-    /// <summary>Optional directory path for writing debug JSON response files. Disabled when empty.</summary>
-    protected virtual string JsonDebugPath { get; set; } = string.Empty;
-
     private static CancellationTokenSource CreateLinkedCts(TimeSpan? timeout, CancellationToken cancellationToken)
     {
         var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -135,12 +132,6 @@ public abstract class HttpClientBase
             else
             {
                 var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-                if (!string.IsNullOrWhiteSpace(json) && !string.IsNullOrWhiteSpace(JsonDebugPath) && Path.Exists(JsonDebugPath))
-                {
-                    var fileName = $"{DateTime.UtcNow.To_yyyy_MM_dd()}-{DateTime.UtcNow.Ticks}-{typeof(TResult)}.json";
-                    var path = Path.Combine(JsonDebugPath, fileName);
-                    await path.WriteAllTextAsync(json, cancellationToken);
-                }
                 tpl.result = json.FromJson<TResult>();
             }
             tpl.error = default;

--- a/src/CasCap.Common.OpenTelemetry/Extensions/OpenTelemetryExtensions.cs
+++ b/src/CasCap.Common.OpenTelemetry/Extensions/OpenTelemetryExtensions.cs
@@ -1,4 +1,4 @@
-namespace CasCap.Extensions;
+namespace CasCap.Common.Extensions;
 
 /// <summary>OpenTelemetry registration extensions for ASP.NET Core applications.</summary>
 public static class OpenTelemetryExtensions

--- a/src/CasCap.Common.OpenTelemetry/README.md
+++ b/src/CasCap.Common.OpenTelemetry/README.md
@@ -2,6 +2,12 @@
 
 Reusable OpenTelemetry configuration with standard metrics, traces, and log exporters via OTLP gRPC, built on top of `CasCap.Common.Abstractions` and `CasCap.Common.Logging.Serilog`.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Common.OpenTelemetry
+```
+
 ## Purpose
 
 Provides a single `InitializeOpenTelemetry` extension method on `WebApplicationBuilder` that registers the full OpenTelemetry pipeline (metrics, traces, and logs) with standard ASP.NET Core instrumentations. Configuration is driven by `IMetricsConfig` — the OTLP endpoint, service name, and metric prefix are all sourced from the application's configuration record.

--- a/src/CasCap.Common.Serialization.Json/Converters/ColumnCleanerConverter.cs
+++ b/src/CasCap.Common.Serialization.Json/Converters/ColumnCleanerConverter.cs
@@ -1,5 +1,5 @@
-﻿/*
-namespace CasCap.Models;
+/*
+namespace CasCap.Common.Models;
 
 public class ColumnCleanerConverter : JsonConverter
 {

--- a/src/CasCap.Common.Serialization.Json/Converters/RawJsonStringConverter.cs
+++ b/src/CasCap.Common.Serialization.Json/Converters/RawJsonStringConverter.cs
@@ -1,0 +1,41 @@
+#if NET8_0_OR_GREATER
+namespace CasCap.Common.Converters;
+
+/// <summary>
+/// <see cref="JsonConverter{T}"/> that writes <see cref="string"/> values as raw JSON when the
+/// content is valid JSON, avoiding double-encoding of serialised payloads.
+/// </summary>
+/// <remarks>
+/// Non-JSON strings are written as plain string values. Useful when a DTO carries a JSON body
+/// as a <see cref="string"/> property and the serialised output should embed it as a nested
+/// object/array rather than an escaped string.
+/// </remarks>
+public sealed class RawJsonStringConverter : JsonConverter<string?>
+{
+    /// <inheritdoc/>
+    public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => reader.GetString();
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        // Attempt to parse as JSON; if valid, write it raw so the output is a nested object/array.
+        try
+        {
+            using var doc = JsonDocument.Parse(value);
+            doc.RootElement.WriteTo(writer);
+        }
+        catch (JsonException)
+        {
+            // Not valid JSON — write as a plain string.
+            writer.WriteStringValue(value);
+        }
+    }
+}
+#endif

--- a/src/CasCap.Common.Serialization.Json/README.md
+++ b/src/CasCap.Common.Serialization.Json/README.md
@@ -28,6 +28,7 @@ Provides convenient `ToJson()` / `FromJson()` extension methods and a library of
 | `ColumnCleanerConverter` | Strips unwanted characters from column names during deserialization |
 | `MicrosecondEpochConverter` | Converts microsecond Unix epoch timestamps to `DateTime` |
 | `MillisecondEpochConverter` | Converts millisecond Unix epoch timestamps to `DateTime` |
+| `RawJsonStringConverter` | Writes `string` values as raw JSON when valid, avoiding double-encoding of serialised payloads (net8.0+ only) |
 | `StringToIntConverter` | Coerces JSON string values to `int` |
 | `UtcJsonDateTimeConverter` | Ensures `DateTime` values are always treated as UTC |
 

--- a/src/CasCap.Common.Serialization.Json/README.md
+++ b/src/CasCap.Common.Serialization.Json/README.md
@@ -2,6 +2,12 @@
 
 `System.Text.Json` serialization helpers and custom `JsonConverter` implementations.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Common.Serialization.Json
+```
+
 ## Purpose
 
 Provides convenient `ToJson()` / `FromJson()` extension methods and a library of custom converters for common serialization scenarios such as epoch timestamps, 2-D array round-tripping, and string-to-int coercion.

--- a/src/CasCap.Common.Serialization.MessagePack/Extensions/MessagePackExtensions.cs
+++ b/src/CasCap.Common.Serialization.MessagePack/Extensions/MessagePackExtensions.cs
@@ -38,7 +38,7 @@ public static class MessagePackExtensions
         try
         {
             T obj = MessagePackSerializer.Deserialize<T>(bytes);
-            //_logger.LogTrace("{ClassName} deserialized object {typeof} from {count} bytes",
+            //_logger.LogTrace("{ClassName} deserialized object {typeof} from {Count} bytes",
             //    nameof(MessagePackSerializationHelpers), typeof(T), bytes.Length);
             return obj;
         }

--- a/src/CasCap.Common.Serialization.MessagePack/README.md
+++ b/src/CasCap.Common.Serialization.MessagePack/README.md
@@ -2,6 +2,12 @@
 
 MessagePack binary serialization helpers using the MessagePack-CSharp library.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Common.Serialization.MessagePack
+```
+
 ## Purpose
 
 Provides `ToMessagePack<T>()` and `FromMessagePack<T>()` extension methods for fast, compact binary serialization. The MessagePack analyzer is included as a development dependency to enforce correct attribute usage at build time.

--- a/src/CasCap.Common.Services/README.md
+++ b/src/CasCap.Common.Services/README.md
@@ -2,6 +2,12 @@
 
 Feature-flag background service launcher and configuration abstractions.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Common.Services
+```
+
 ## Purpose
 
 Contains `FeatureFlagBgService`, a `BackgroundService` that inspects the configured `FeatureFlagConfig.EnabledFeatures` set at startup and launches the matching `IBgFeature` implementations registered in the DI container. The `AddFeatureFlagService()` extension wires everything up.

--- a/src/CasCap.Common.Testing/README.md
+++ b/src/CasCap.Common.Testing/README.md
@@ -2,6 +2,12 @@
 
 xUnit test infrastructure — logging redirection and conditional-skip attributes for CI environments.
 
+## Installation
+
+```bash
+dotnet add package CasCap.Common.Testing
+```
+
 ## Purpose
 
 Provides utilities that route `ILogger` output to xUnit's `ITestOutputHelper` via Serilog, plus `[Fact]`/`[Theory]` attributes that automatically skip tests when running under Azure DevOps or GitHub Actions.


### PR DESCRIPTION
## Summary

Two main changes: a new HTTP request/response auditing pipeline and a bulk namespace standardization across all `CasCap.Common.*` projects.

## HTTP Auditing

New infrastructure for capturing and persisting HTTP request/response pairs from typed `HttpClient` pipelines.

### CasCap.Common.Abstractions
- `IHttpAuditStore` — abstraction for persisting audit entries (net8.0+)
- `HttpAuditEntry` — record representing a single request/response audit record (`Source`, `HttpMethod`, `RequestUri`, `StatusCode`, `ElapsedMs`, `RequestBody`, `ResponseBody`)

### CasCap.Common.Net
- `HttpAuditHandler` — `DelegatingHandler` that captures request/response pairs and persists them via `IHttpAuditStore`
- `HttpAuditSource` — `HttpRequestOptionsKey` for tagging requests with a logical source name
- `FileHttpAuditStore` — lightweight file-based `IHttpAuditStore` fallback that writes JSON files into daily `yyyy-MM-dd` sub-folders
- `HttpClientBuilderAuditExtensions.AddHttpAuditing(sourceName)` — one-liner to wire auditing into any `IHttpClientBuilder`

### CasCap.Common.Serialization.Json
- `RawJsonStringConverter` — `JsonConverter<string?>` that writes valid JSON string values as raw JSON objects (avoids double-encoding serialised payloads)

## Namespace Standardization

All internal namespaces in `CasCap.Common.*` projects now use the `CasCap.Common.*` prefix consistently:

| Old Namespace | New Namespace | Projects Affected |
| --- | --- | --- |
| `CasCap.Abstractions` | `CasCap.Common.Abstractions` | AI |
| `CasCap.Authentication` | `CasCap.Common.Authentication` | Net |
| `CasCap.Extensions` | `CasCap.Common.Extensions` | AI, OpenTelemetry |
| `CasCap.Models` | `CasCap.Common.Models` | AI |
| `CasCap.Services` | `CasCap.Common.Services` | AI |

Framework extension namespaces (`Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Logging`, `Serilog`, `System.Runtime.CompilerServices`) are intentionally unchanged.

## Other Changes

- Removed unused `PostFormAsync` method from `HttpClientBase`
- Fixed potential `Task.WhenAll` issue in `CacheExpiryBgService`
- Updated NuGet dependencies
- Updated all project READMEs