### PR TITLE
Add ParseEnumConverter<TEnum> and bump NuGet dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,19 +8,19 @@
     <PackageVersion Include="MessagePack" Version="3.1.4" />
     <PackageVersion Include="MessagePackAnalyzer" Version="3.1.4" />
     <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.5.2" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.5.2" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.5.2" />
@@ -52,7 +52,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.15.1-beta.1" />
     <PackageVersion Include="RedLock.net" Version="2.3.2" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.12.14" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.13.1" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="coverlet.msbuild" Version="10.0.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,9 +21,9 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.5.2" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.5.2" />
-    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.5.2" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.6.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.6.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.6.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />

--- a/src/CasCap.Common.Serialization.Json/Converters/ParseEnumConverter{TEnum}.cs
+++ b/src/CasCap.Common.Serialization.Json/Converters/ParseEnumConverter{TEnum}.cs
@@ -1,0 +1,13 @@
+namespace CasCap.Common.Converters;
+
+/// <summary>Case-insensitive JSON string-to-enum converter using <see cref="Enum.Parse{TEnum}(string, bool)"/>.</summary>
+public class ParseEnumConverter<TEnum> : JsonConverter<TEnum> where TEnum : struct, Enum
+{
+    /// <inheritdoc/>
+    public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+        Enum.Parse<TEnum>(reader.GetString()!, true);
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options) =>
+        writer.WriteStringValue(value.ToString());
+}

--- a/src/CasCap.Common.Serialization.Json/Converters/ParseEnumConverter{TEnum}.cs
+++ b/src/CasCap.Common.Serialization.Json/Converters/ParseEnumConverter{TEnum}.cs
@@ -5,7 +5,11 @@ public class ParseEnumConverter<TEnum> : JsonConverter<TEnum> where TEnum : stru
 {
     /// <inheritdoc/>
     public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+#if NETSTANDARD2_0
+        (TEnum)Enum.Parse(typeof(TEnum), reader.GetString()!, true);
+#else
         Enum.Parse<TEnum>(reader.GetString()!, true);
+#endif
 
     /// <inheritdoc/>
     public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options) =>

--- a/src/CasCap.Common.Serialization.Json/README.md
+++ b/src/CasCap.Common.Serialization.Json/README.md
@@ -28,6 +28,7 @@ Provides convenient `ToJson()` / `FromJson()` extension methods and a library of
 | `ColumnCleanerConverter` | Strips unwanted characters from column names during deserialization |
 | `MicrosecondEpochConverter` | Converts microsecond Unix epoch timestamps to `DateTime` |
 | `MillisecondEpochConverter` | Converts millisecond Unix epoch timestamps to `DateTime` |
+| `ParseEnumConverter<TEnum>` | Case-insensitive string-to-enum converter using `Enum.Parse<TEnum>()` |
 | `RawJsonStringConverter` | Writes `string` values as raw JSON when valid, avoiding double-encoding of serialised payloads (net8.0+ only) |
 | `StringToIntConverter` | Coerces JSON string values to `int` |
 | `UtcJsonDateTimeConverter` | Ensures `DateTime` values are always treated as UTC |


### PR DESCRIPTION
## Changes

### New converter

- Add `ParseEnumConverter<TEnum>` to `CasCap.Common.Serialization.Json` — a case-insensitive JSON string-to-enum converter using `Enum.Parse<TEnum>()`, with `#if NETSTANDARD2_0` guard for multi-targeting support.
- Update project README with the new converter entry.

### Dependency updates

| Package | From | To |
| --- | --- | --- |
| `Microsoft.Extensions.*` (core) | 10.0.7 | 10.0.8 |
| `Microsoft.Extensions.Http.Resilience` | 10.5.0 | 10.6.0 |
| `Microsoft.Extensions.AI*` | 10.5.2 | 10.6.0 |
| `StackExchange.Redis` | 2.12.14 | 2.13.1 |