### PR TITLE
Bug fixes (Pow recursion, EnumExtensions thread-safety) + Path.Combine → Extend refactoring + NuGet updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,9 +5,9 @@
   <ItemGroup>
     <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
-    <PackageVersion Include="MessagePack" Version="3.1.4" />
-    <PackageVersion Include="MessagePackAnalyzer" Version="3.1.4" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.6.1" />
+    <PackageVersion Include="MessagePack" Version="3.1.6" />
+    <PackageVersion Include="MessagePackAnalyzer" Version="3.1.6" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.6.2" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.8" />
@@ -40,7 +40,7 @@
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.19" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.Agents.AI" Version="1.6.1" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.6.2" />
     <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
     <PackageVersion Include="OllamaSharp" Version="5.4.25" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/src/CasCap.Common.Caching/Models/_CachingConfig.cs
+++ b/src/CasCap.Common.Caching/Models/_CachingConfig.cs
@@ -42,7 +42,7 @@ public record CachingConfig : IAppConfig
     public CacheParameters RemoteCache { get; set; } = new CacheParameters { SerializationType = SerializationType.MessagePack };
 
     /// <summary>Specifies the root folder where the local disk cache will store serialized files.</summary>
-    public string DiskCacheFolder { get; init; } = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "cache");
+    public string DiskCacheFolder { get; init; } = AppDomain.CurrentDomain.BaseDirectory.Extend("cache");
 
     /// <summary>Enables pub/sub-based invalidation of local cache entries across distributed clients.</summary>
     public bool LocalCacheInvalidationEnabled { get; set; } = true;

--- a/src/CasCap.Common.Caching/Services/DiskCacheService.cs
+++ b/src/CasCap.Common.Caching/Services/DiskCacheService.cs
@@ -139,7 +139,7 @@ public class DiskCacheService : ILocalCache
     {
         if (string.IsNullOrWhiteSpace(_diskCacheFolder))
             throw new ArgumentException($"to use {nameof(DiskCacheService)} you must set the {nameof(_cachingConfig.DiskCacheFolder)}");
-        return Path.Combine(_diskCacheFolder, key.Replace(":", "_"));
+        return _diskCacheFolder.Extend(key.Replace(":", "_"));
     }
 
     /// <summary>

--- a/src/CasCap.Common.Caching/Services/DiskCacheService.cs
+++ b/src/CasCap.Common.Caching/Services/DiskCacheService.cs
@@ -34,7 +34,7 @@ public class DiskCacheService : ILocalCache
         _logger = logger;
         _cachingConfig = cachingConfig.Value;
         _diskCacheFolder = _cachingConfig.DiskCacheFolder;
-        if (!Directory.Exists(_diskCacheFolder)) Directory.CreateDirectory(_diskCacheFolder);
+        _diskCacheFolder.EnsureDirectoryExists();
         if (_cachingConfig.DiskCache.ClearOnStartup) DeleteAll();
     }
 

--- a/src/CasCap.Common.Extensions.Tests/Tests/IOExtensionTests.cs
+++ b/src/CasCap.Common.Extensions.Tests/Tests/IOExtensionTests.cs
@@ -8,9 +8,9 @@ public class IOExtensionTests(ITestOutputHelper testOutputHelper) : TestBase(tes
     public async Task IO()
     {
         //Arrange
-        var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "cache");
-        var filePath1 = Path.Combine(path, "test.txt");
-        var filePath2 = Path.Combine(path, "test.bin");
+        var path = AppDomain.CurrentDomain.BaseDirectory.Extend("cache");
+        var filePath1 = path.Extend("test.txt");
+        var filePath2 = path.Extend("test.bin");
         //cleanup
         if (Directory.Exists(path))
             Directory.Delete(path, true);

--- a/src/CasCap.Common.Extensions/Extensions/EnumExtensions.cs
+++ b/src/CasCap.Common.Extensions/Extensions/EnumExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 
@@ -27,22 +28,13 @@ public static class EnumExtensions
     /// <summary>Handy to find originating method name when debugging.</summary>
     public static string GetCallingMethodName([CallerMemberName] string caller = "") => caller;
 
-    private static Dictionary<Enum, string> enumStringValues = new();
+    private static readonly ConcurrentDictionary<Enum, string> s_enumStringValues = new();
 
     /// <summary>Returns the cached string representation of the specified <see cref="Enum"/> value.</summary>
     /// <param name="myEnum">The enum value.</param>
     /// <returns>The cached string representation.</returns>
     public static string ToStringCached(this Enum myEnum)
-    {
-        if (enumStringValues.TryGetValue(myEnum, out var textValue))
-            return textValue;
-        else
-        {
-            textValue = myEnum.ToString();
-            enumStringValues[myEnum] = textValue;
-            return textValue;
-        }
-    }
+        => s_enumStringValues.GetOrAdd(myEnum, static e => e.ToString());
 
     /// <summary>
     /// Gets the <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute"/> name for the specified <see cref="Enum"/> value.

--- a/src/CasCap.Common.Extensions/Extensions/IOExtensions.cs
+++ b/src/CasCap.Common.Extensions/Extensions/IOExtensions.cs
@@ -15,6 +15,23 @@ public static class IOExtensions
     public static string Extend(this string root, string folderOrFile)
         => Path.Combine(root, folderOrFile);
 
+    /// <summary>Combines a root path with two relative path segments.</summary>
+    /// <param name="root">The root directory path.</param>
+    /// <param name="path1">The first relative path segment.</param>
+    /// <param name="path2">The second relative path segment.</param>
+    /// <returns>The combined path.</returns>
+    public static string Extend(this string root, string path1, string path2)
+        => Path.Combine(root, path1, path2);
+
+    /// <summary>Combines a root path with three relative path segments.</summary>
+    /// <param name="root">The root directory path.</param>
+    /// <param name="path1">The first relative path segment.</param>
+    /// <param name="path2">The second relative path segment.</param>
+    /// <param name="path3">The third relative path segment.</param>
+    /// <returns>The combined path.</returns>
+    public static string Extend(this string root, string path1, string path2, string path3)
+        => Path.Combine(root, path1, path2, path3);
+
     /// <summary>Ensures the directory at the specified path exists, creating it if necessary.</summary>
     /// <param name="directoryPath">The directory path to ensure exists.</param>
     /// <returns>The same directory path for fluent chaining.</returns>

--- a/src/CasCap.Common.Extensions/Extensions/IOExtensions.cs
+++ b/src/CasCap.Common.Extensions/Extensions/IOExtensions.cs
@@ -15,13 +15,15 @@ public static class IOExtensions
     public static string Extend(this string root, string folderOrFile)
         => Path.Combine(root, folderOrFile);
 
-    //public static string ExtendAndCreateDirectory(this string root, string folderOrFile)
-    //{
-    //    var directory = root.ExtendPath(Path.GetFullPath(folderOrFile));
-    //    if (!Directory.Exists(directory))
-    //        Directory.CreateDirectory(directory);
-    //    return directory;
-    //}
+    /// <summary>Ensures the directory at the specified path exists, creating it if necessary.</summary>
+    /// <param name="directoryPath">The directory path to ensure exists.</param>
+    /// <returns>The same directory path for fluent chaining.</returns>
+    public static string EnsureDirectoryExists(this string directoryPath)
+    {
+        if (!Directory.Exists(directoryPath))
+            Directory.CreateDirectory(directoryPath);
+        return directoryPath;
+    }
 
     /// <summary>Writes all bytes to the specified path, creating the directory if it does not exist.</summary>
     /// <param name="path">The file path to write to.</param>
@@ -33,6 +35,29 @@ public static class IOExtensions
         {
             if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
             File.WriteAllBytes(path, bytes);
+        }
+        else
+            throw new GenericException($"GetDirectoryName not possible for path '{path}'");
+    }
+
+    /// <summary>
+    /// Asynchronously writes all bytes to the specified path, creating the directory if it does not exist.
+    /// </summary>
+    /// <param name="path">The file path to write to.</param>
+    /// <param name="bytes">The byte content to write.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
+    public static async Task WriteAllBytesAsync(this string path, byte[] bytes, CancellationToken cancellationToken)
+    {
+        var dir = Path.GetDirectoryName(path);
+        if (dir is not null)
+        {
+            if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+#if NET8_0_OR_GREATER
+            await File.WriteAllBytesAsync(path, bytes, cancellationToken);
+#else
+            await Task.Delay(0, cancellationToken);
+            File.WriteAllBytes(path, bytes);
+#endif
         }
         else
             throw new GenericException($"GetDirectoryName not possible for path '{path}'");

--- a/src/CasCap.Common.Extensions/Extensions/ParseExtensions.cs
+++ b/src/CasCap.Common.Extensions/Extensions/ParseExtensions.cs
@@ -254,12 +254,12 @@ public static class ParseExtensions
     //this will be faster than the bitmask variant below
     private static int Pow(int exp) => exp switch
     {
-        0 => exp,
-        1 => exp *= 10,
-        2 => exp *= 100,
-        3 => exp *= 1000,
-        4 => exp *= 10000,
-        _ => exp *= Pow(exp)
+        0 => 1,
+        1 => 10,
+        2 => 100,
+        3 => 1000,
+        4 => 10000,
+        _ => Pow(exp, 10)
     };
 
     //https://stackoverflow.com/questions/2065249/c-sharp-efficient-algorithm-integer-based-power-function

--- a/src/CasCap.Common.Net/Auditing/FileHttpAuditStore.cs
+++ b/src/CasCap.Common.Net/Auditing/FileHttpAuditStore.cs
@@ -31,11 +31,11 @@ public sealed class FileHttpAuditStore(
     public async Task SaveAsync(HttpAuditEntry entry, CancellationToken cancellationToken = default)
     {
         var datePart = entry.TimestampUtc.ToString("yyyy-MM-dd");
-        var dayDir = Path.Combine(outputDirectory, datePart).EnsureDirectoryExists();
+        var dayDir = outputDirectory.Extend(datePart).EnsureDirectoryExists();
 
         var timestamp = entry.TimestampUtc.ToString("HHmmss-fff");
         var fileName = $"{timestamp}_{entry.Source}_{entry.StatusCode}.json";
-        var filePath = Path.Combine(dayDir, fileName);
+        var filePath = dayDir.Extend(fileName);
 
         await using var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None,
             bufferSize: 4096, useAsync: true);

--- a/src/CasCap.Common.Net/Auditing/FileHttpAuditStore.cs
+++ b/src/CasCap.Common.Net/Auditing/FileHttpAuditStore.cs
@@ -31,8 +31,7 @@ public sealed class FileHttpAuditStore(
     public async Task SaveAsync(HttpAuditEntry entry, CancellationToken cancellationToken = default)
     {
         var datePart = entry.TimestampUtc.ToString("yyyy-MM-dd");
-        var dayDir = Path.Combine(outputDirectory, datePart);
-        Directory.CreateDirectory(dayDir);
+        var dayDir = Path.Combine(outputDirectory, datePart).EnsureDirectoryExists();
 
         var timestamp = entry.TimestampUtc.ToString("HHmmss-fff");
         var fileName = $"{timestamp}_{entry.Source}_{entry.StatusCode}.json";


### PR DESCRIPTION
## Summary

Bug fixes, IO extension enhancements, and NuGet package updates.

## Bug Fixes

### `ParseExtensions.Pow` — infinite recursion (critical)

The single-arg `Pow(int exp)` switch expression had two issues:
- Cases 0–4 incorrectly mutated the `exp` parameter (e.g. `1 => exp *= 10`) — produced correct results by coincidence but was semantically wrong.
- The `_ =>` fallback called `Pow(exp)` recursively with the **same** value, causing a `StackOverflowException` for any `exp >= 5`.

Fixed by returning literal power-of-10 constants for cases 0–4 and delegating to the existing `Pow(exp, 10)` bit-shift overload for the fallback.

### `EnumExtensions.ToStringCached` — thread-safety (high)

The method used a plain `Dictionary<Enum, string>` without synchronization. Concurrent callers could corrupt the dictionary or throw `InvalidOperationException`.

Fixed by replacing with `ConcurrentDictionary<Enum, string>` and simplifying to a single `GetOrAdd` call with a static lambda.

## Enhancements

### `IOExtensions` — `Path.Combine` → `.Extend()` refactoring

- Added 2-arg and 3-arg `Extend` overloads for multi-segment path composition.
- Added `EnsureDirectoryExists()` extension for fluent directory creation.
- Added `WriteAllBytesAsync` extension with async file I/O on NET8+.
- Replaced all `Path.Combine` + `Directory.CreateDirectory` patterns across the codebase with the new extensions.

### Affected files

- `DiskCacheService.cs` — uses `Extend` and `EnsureDirectoryExists`
- `FileHttpAuditStore.cs` — uses `Extend` and `EnsureDirectoryExists`
- `_CachingConfig.cs` — `DiskCacheFolder` default uses `Extend`
- `IOExtensionTests.cs` — updated to use `Extend`

## NuGet Updates

| Package | From | To |
| --- | --- | --- |
| MessagePack | 3.1.4 | 3.1.6 |
| MessagePackAnalyzer | 3.1.4 | 3.1.6 |
| Microsoft.Agents.AI | 1.6.1 | 1.6.2 |
| Microsoft.Agents.AI.Workflows | 1.6.1 | 1.6.2 |