### PR TITLE
refactor: remove GetEvents from IEventSink<T>, add SinkType property

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageVersion Include="MessagePack" Version="3.1.6" />
     <PackageVersion Include="MessagePackAnalyzer" Version="3.1.6" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.6.2" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.8" />
@@ -24,7 +24,7 @@
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.6.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.6.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.6.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Enrichers.AssemblyName" Version="2.0.0" />
@@ -40,7 +40,7 @@
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.19" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.Agents.AI" Version="1.6.2" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.7.0" />
     <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
     <PackageVersion Include="OllamaSharp" Version="5.4.25" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/src/CasCap.Common.Abstractions/Abstractions/IEventSink{T}.cs
+++ b/src/CasCap.Common.Abstractions/Abstractions/IEventSink{T}.cs
@@ -21,12 +21,6 @@ public interface IEventSink<T>
     /// <summary>Writes a single event to the sink.</summary>
     Task WriteEvent(T @event, CancellationToken cancellationToken = default);
 
-    /// <summary>Retrieves events from the sink, optionally filtered by <paramref name="id"/>.</summary>
-    /// <param name="id">Optional identifier to filter events.</param>
-    /// <param name="limit">Maximum number of events to return. Defaults to <c>1000</c>.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    IAsyncEnumerable<T> GetEvents(string? id = null, int limit = 1000, CancellationToken cancellationToken = default);
-
     /// <summary>
     /// Performs housekeeping by removing entries whose identifiers are not in <paramref name="validIds"/>.
     /// The default implementation is a no-op.

--- a/src/CasCap.Common.Abstractions/Abstractions/IEventSink{T}.cs
+++ b/src/CasCap.Common.Abstractions/Abstractions/IEventSink{T}.cs
@@ -4,6 +4,9 @@ namespace CasCap.Common.Abstractions;
 /// <typeparam name="T">The event type handled by this sink.</typeparam>
 public interface IEventSink<T>
 {
+    /// <summary>The sink type identifier used for targeted dispatch filtering.</summary>
+    string SinkType { get; }
+
     /// <summary>
     /// Performs any one-time initialization required by the sink (e.g. starting background flush loops).
     /// The default implementation is a no-op.

--- a/src/CasCap.Common.Abstractions/README.md
+++ b/src/CasCap.Common.Abstractions/README.md
@@ -21,7 +21,7 @@ This library contains no concrete implementations — only interfaces and abstra
 | [`IAppConfig`](Abstractions/_IAppConfig.cs) | Marker interface implemented by all application configuration records to allow easy identification and generic constraint usage |
 | [`IBgFeature`](Abstractions/IBgFeature.cs) | Identifies a feature-gated background service — exposes a string `FeatureName` and `ExecuteAsync` entry point. Matched case-insensitively against the enabled features set at startup |
 | [`IFeature<T>`](Abstractions/IFeature%7BT%7D.cs) | **[Obsolete]** Generic predecessor of `IBgFeature` that used a bitwise feature-flag enum via `FeatureType`. Retained for backward compatibility |
-| [`IEventSink<T>`](Abstractions/IEventSink%7BT%7D.cs) | Generic event sink contract (unconstrained — accepts both reference and value types). Exposes a `SinkType` property for targeted dispatch filtering. Domain events are fanned out to every registered `IEventSink<T>` implementation in parallel |
+| [`IEventSink<T>`](Abstractions/IEventSink%7BT%7D.cs) | Generic write-path event sink contract (unconstrained — accepts both reference and value types). Exposes a `SinkType` property for targeted dispatch filtering. Domain events are fanned out to every registered `IEventSink<T>` implementation in parallel. Read-path queries are defined by domain-specific interfaces (e.g. `IFroniusQuery`, `IKnxQuery`) in the consuming projects |
 | [`ILocalCache`](Abstractions/ILocalCache.cs) | Abstraction for an in-process cache provider supporting `Get`, `Set`, `Delete`, and `DeleteAll` |
 | [`IMyBlob`](Abstractions/IMyBlob.cs) | Represents a blob with associated metadata (`bytes`, `DateCreatedUtc`, `BlobName`, `SizeInBytes`, `HasImage`) |
 | [`INotifier`](Abstractions/INotifier.cs) | Abstracts a notification service capable of sending and receiving messages with optional attachment support |
@@ -83,13 +83,14 @@ This library contains no concrete implementations — only interfaces and abstra
 string SinkType { get; }
 Task InitializeAsync(CancellationToken cancellationToken);
 Task WriteEvent(T @event, CancellationToken cancellationToken = default);
-IAsyncEnumerable<T> GetEvents(string? id = null, int limit = 1000, CancellationToken cancellationToken = default);
 Task HousekeepingAsync(IReadOnlyCollection<string> validIds, CancellationToken cancellationToken = default);
 ```
 
 `SinkType` is a self-describing property that each implementation sets to its own sink identifier (e.g. `"Redis"`, `"AzureTables"`, `"Console"`). This enables targeted dispatch filtering at runtime without reflection. The value should match the string passed to [`SinkTypeAttribute`](Attributes/SinkTypeAttribute.cs) on the same class.
 
-`InitializeAsync` and `HousekeepingAsync` have default no-op implementations so that sink authors only need to implement `SinkType`, `WriteEvent` and `GetEvents`.
+`InitializeAsync` and `HousekeepingAsync` have default no-op implementations so that sink authors only need to implement `SinkType` and `WriteEvent`.
+
+Read-path queries (retrieving stored events, snapshots) are intentionally **not** part of this interface. Each domain defines its own query interface (e.g. `IFroniusQuery`, `IKnxQuery`) with methods tailored to the domain's access patterns. This follows the Interface Segregation Principle — write-only sinks (e.g. Console, SignalR) are not forced to implement read methods they cannot support.
 
 ## Dependencies
 

--- a/src/CasCap.Common.Abstractions/README.md
+++ b/src/CasCap.Common.Abstractions/README.md
@@ -18,75 +18,78 @@ This library contains no concrete implementations — only interfaces and abstra
 
 | Interface | Description |
 | --- | --- |
-| `IAppConfig` | Marker interface implemented by all application configuration records to allow easy identification and generic constraint usage |
-| `IBgFeature` | Identifies a feature-gated background service — exposes a string `FeatureName` and `ExecuteAsync` entry point. Matched case-insensitively against the enabled features set at startup |
-| `IFeature<T>` | **[Obsolete]** Generic predecessor of `IBgFeature` that used a bitwise feature-flag enum via `FeatureType`. Retained for backward compatibility |
-| `IEventSink<T>` | Generic event sink contract (unconstrained — accepts both reference and value types). Domain events are fanned out to every registered `IEventSink<T>` implementation in parallel |
-| `ILocalCache` | Abstraction for an in-process cache provider supporting `Get`, `Set`, `Delete`, and `DeleteAll` |
-| `IMyBlob` | Represents a blob with associated metadata (`bytes`, `DateCreatedUtc`, `BlobName`, `SizeInBytes`, `HasImage`) |
-| `INotifier` | Abstracts a notification service capable of sending and receiving messages with optional attachment support |
-| `INotificationMessage` | Represents an outgoing notification message (text, sender, recipients, attachments) |
-| `INotificationAttachment` | Metadata for an attachment received as part of a notification (`Id`, `ContentType`) |
-| `INotificationGroup` | Represents a named group in a notification service (`Id`, `Name`, members) |
-| `INotificationResponse` | Response returned after sending a notification (`Timestamp`) |
-| `IReceivedNotification` | Represents a notification received from an external messaging service (`Sender`, `GroupId`, `Message`, attachments) |
-| `IHttpAuditStore` | Abstraction for persisting HTTP audit entries (net8.0+ only) |
-| `IAzBlobStorageConfig` | Exposes Azure Blob Storage connection properties (endpoint/connection string, container name, health check probe type) for feature-specific configuration records |
-| `IAzTableStorageConfig` | Exposes Azure Table Storage connection properties (endpoint/connection string, health check probe type) for feature-specific configuration records |
-| `IFeatureConfig<T>` | **[Obsolete]** Pairs with `IFeature<T>` to carry the enabled `EnabledFeatures` flags into the `BackgroundService` launcher |
-| `IKubeAppConfig` | Exposes Kubernetes-specific runtime properties (node name, pod name, namespace, pod IP, service account name) |
-| `IMetricsConfig` | Exposes OpenTelemetry metric configuration (metric name prefix, OTel service name) |
+| [`IAppConfig`](Abstractions/_IAppConfig.cs) | Marker interface implemented by all application configuration records to allow easy identification and generic constraint usage |
+| [`IBgFeature`](Abstractions/IBgFeature.cs) | Identifies a feature-gated background service — exposes a string `FeatureName` and `ExecuteAsync` entry point. Matched case-insensitively against the enabled features set at startup |
+| [`IFeature<T>`](Abstractions/IFeature%7BT%7D.cs) | **[Obsolete]** Generic predecessor of `IBgFeature` that used a bitwise feature-flag enum via `FeatureType`. Retained for backward compatibility |
+| [`IEventSink<T>`](Abstractions/IEventSink%7BT%7D.cs) | Generic event sink contract (unconstrained — accepts both reference and value types). Exposes a `SinkType` property for targeted dispatch filtering. Domain events are fanned out to every registered `IEventSink<T>` implementation in parallel |
+| [`ILocalCache`](Abstractions/ILocalCache.cs) | Abstraction for an in-process cache provider supporting `Get`, `Set`, `Delete`, and `DeleteAll` |
+| [`IMyBlob`](Abstractions/IMyBlob.cs) | Represents a blob with associated metadata (`bytes`, `DateCreatedUtc`, `BlobName`, `SizeInBytes`, `HasImage`) |
+| [`INotifier`](Abstractions/INotifier.cs) | Abstracts a notification service capable of sending and receiving messages with optional attachment support |
+| [`INotificationMessage`](Abstractions/INotificationMessage.cs) | Represents an outgoing notification message (text, sender, recipients, attachments) |
+| [`INotificationAttachment`](Abstractions/INotificationAttachment.cs) | Metadata for an attachment received as part of a notification (`Id`, `ContentType`) |
+| [`INotificationGroup`](Abstractions/INotificationGroup.cs) | Represents a named group in a notification service (`Id`, `Name`, members) |
+| [`INotificationResponse`](Abstractions/INotificationResponse.cs) | Response returned after sending a notification (`Timestamp`) |
+| [`IReceivedNotification`](Abstractions/IReceivedNotification.cs) | Represents a notification received from an external messaging service (`Sender`, `GroupId`, `Message`, attachments) |
+| [`IHttpAuditStore`](Abstractions/IHttpAuditStore.cs) | Abstraction for persisting HTTP audit entries (net8.0+ only) |
+| [`IAzBlobStorageConfig`](Abstractions/_IAzBlobStorageConfig.cs) | Exposes Azure Blob Storage connection properties (endpoint/connection string, container name, health check probe type) for feature-specific configuration records |
+| [`IAzTableStorageConfig`](Abstractions/_IAzTableStorageConfig.cs) | Exposes Azure Table Storage connection properties (endpoint/connection string, health check probe type) for feature-specific configuration records |
+| [`IFeatureConfig<T>`](Abstractions/_IFeatureConfig%7BT%7D.cs) | **[Obsolete]** Pairs with `IFeature<T>` to carry the enabled `EnabledFeatures` flags into the `BackgroundService` launcher |
+| [`IKubeAppConfig`](Abstractions/_IKubeAppConfig.cs) | Exposes Kubernetes-specific runtime properties (node name, pod name, namespace, pod IP, service account name) |
+| [`IMetricsConfig`](Abstractions/_IMetricsConfig.cs) | Exposes OpenTelemetry metric configuration (metric name prefix, OTel service name) |
 
 ### Enums
 
 | Type | Description |
 | --- | --- |
-| `KubernetesProbeTypes` | `[Flags]` enum for Kubernetes container health probe types: `None`, `Readiness`, `Liveness`, `Startup` |
+| [`KubernetesProbeTypes`](_Enums.cs) | `[Flags]` enum for Kubernetes container health probe types: `None`, `Readiness`, `Liveness`, `Startup` |
 
 ### Configuration Types
 
 | Type | Description |
 | --- | --- |
-| `ApiAuthConfig` | Basic authentication settings for a REST API (`Username`, `Password`, `AnonymousPathPrefixes`) |
-| `SinkConfig` | Dictionary of `SinkTypeAttribute` name → `SinkConfigParams` |
-| `SinkConfigParams` | Per-sink settings: `Enabled`, and a `Settings` dictionary for sink-specific key/value settings |
-| `SinkSettingKeys` | Compile-time constants for common sink setting keys |
+| [`ApiAuthConfig`](Models/_ApiAuthConfig.cs) | Basic authentication settings for a REST API (`Username`, `Password`, `AnonymousPathPrefixes`) |
+| [`SinkConfig`](Models/_SinkConfig.cs) | Dictionary of [`SinkTypeAttribute`](Attributes/SinkTypeAttribute.cs) name → [`SinkConfigParams`](Models/_SinkConfigParams.cs) |
+| [`SinkConfigParams`](Models/_SinkConfigParams.cs) | Per-sink settings: `Enabled`, and a `Settings` dictionary for sink-specific key/value settings |
+| [`SinkSettingKeys`](Models/SinkSettingKeys.cs) | Compile-time constants for common sink setting keys |
 
 ### Models
 
 | Type | Description |
 | --- | --- |
-| `HttpAuditEntry` | Represents a single HTTP request/response audit record — `Source`, `HttpMethod`, `RequestUri`, `StatusCode`, `ElapsedMs`, `RequestBody`, `ResponseBody` (net8.0+ only) |
+| [`HttpAuditEntry`](Abstractions/HttpAuditEntry.cs) | Represents a single HTTP request/response audit record — `Source`, `HttpMethod`, `RequestUri`, `StatusCode`, `ElapsedMs`, `RequestBody`, `ResponseBody` (net8.0+ only) |
 
 ### Event Models
 
 | Type | Description |
 | --- | --- |
-| `CommsEvent` | A comms stream entry with `Source`, `Message`, `TimestampUtc`, and optional `JsonPayload` for AI agent context |
+| [`CommsEvent`](Models/CommsEvent.cs) | A comms stream entry with `Source`, `Message`, `TimestampUtc`, and optional `JsonPayload` for AI agent context |
 
 ### Attributes
 
 | Attribute | Description |
 | --- | --- |
-| `SinkTypeAttribute` | Decorates `IEventSink<T>` implementations with a string type name (e.g. `"Redis"`, `"AzureTables"`, `"Console"`) used by `AddEventSinks()` for discovery |
+| [`SinkTypeAttribute`](Attributes/SinkTypeAttribute.cs) | Decorates [`IEventSink<T>`](Abstractions/IEventSink%7BT%7D.cs) implementations with a string type name (e.g. `"Redis"`, `"AzureTables"`, `"Console"`) used by [`AddEventSinks()`](Extensions/SinkServiceCollectionExtensions.cs) for discovery |
 
 ### Extension Methods
 
 | Method | Description |
 | --- | --- |
-| `IServiceCollection.AddEventSinks<T>(SinkConfig, Assembly)` | Discovers and registers all `IEventSink<T>` implementations in the supplied assembly whose `SinkTypeAttribute` name is enabled in `SinkConfig` |
+| [`IServiceCollection.AddEventSinks<T>(SinkConfig, Assembly)`](Extensions/SinkServiceCollectionExtensions.cs) | Discovers and registers all [`IEventSink<T>`](Abstractions/IEventSink%7BT%7D.cs) implementations in the supplied assembly whose [`SinkTypeAttribute`](Attributes/SinkTypeAttribute.cs) name is enabled in [`SinkConfig`](Models/_SinkConfig.cs) |
 | `KubernetesProbeTypes.GetTags()` | Returns the string health-check tag array for a probe type (`"ready"`, `"live"`, `"startup"`) |
 
-### `IEventSink<T>` Contract
+### [`IEventSink<T>`](Abstractions/IEventSink%7BT%7D.cs) Contract
 
 ```csharp
+string SinkType { get; }
 Task InitializeAsync(CancellationToken cancellationToken);
 Task WriteEvent(T @event, CancellationToken cancellationToken = default);
 IAsyncEnumerable<T> GetEvents(string? id = null, int limit = 1000, CancellationToken cancellationToken = default);
 Task HousekeepingAsync(IReadOnlyCollection<string> validIds, CancellationToken cancellationToken = default);
 ```
 
-`InitializeAsync` and `HousekeepingAsync` have default no-op implementations so that sink authors only need to implement `WriteEvent` and `GetEvents`.
+`SinkType` is a self-describing property that each implementation sets to its own sink identifier (e.g. `"Redis"`, `"AzureTables"`, `"Console"`). This enables targeted dispatch filtering at runtime without reflection. The value should match the string passed to [`SinkTypeAttribute`](Attributes/SinkTypeAttribute.cs) on the same class.
+
+`InitializeAsync` and `HousekeepingAsync` have default no-op implementations so that sink authors only need to implement `SinkType`, `WriteEvent` and `GetEvents`.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

Applies the Interface Segregation Principle to `IEventSink<T>` — the interface is now a **write-path only** contract. Read-path queries move to domain-specific interfaces in consuming projects.

## Changes

### `IEventSink<T>` (breaking)

- **Added** `string SinkType { get; }` — self-describing property for targeted dispatch filtering at runtime without reflection
- **Removed** `GetEvents(string?, int, CancellationToken)` — ~60% of sink implementations were throwing `NotImplementedException` (Console, SignalR, MQTT, etc.), violating ISP

### README

- Added deep-links to all interface/type/attribute file paths
- Updated contract section to reflect the new shape
- Documented the ISP rationale for domain-specific query interfaces

### NuGet Updates

- `Microsoft.Agents.AI` / `Microsoft.Agents.AI.Workflows` 1.6.2 → 1.7.0
- `Microsoft.NET.Test.Sdk` 18.5.1 → 18.6.0

## Migration Guide

Sink implementations that previously threw from `GetEvents` can simply delete the method — it no longer exists on the interface.

Sinks that had real `GetEvents` implementations should now implement a domain-specific query interface (e.g. `IFroniusQuery`, `IShellyQuery`) alongside `IEventSink<T>`. The `AddEventSinks<T>()` extension auto-registers additional interfaces on the same class as non-keyed singletons forwarding to the keyed instance.