### PR TITLE
NuGet updates, CommsEvent Environment property, Redis database ID support, ParseExtensions guard

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,25 +5,25 @@
   <ItemGroup>
     <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
-    <PackageVersion Include="MessagePack" Version="3.1.6" />
-    <PackageVersion Include="MessagePackAnalyzer" Version="3.1.6" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.6.0" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.6.0" />
-    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.6.0" />
+    <PackageVersion Include="MessagePack" Version="3.1.7" />
+    <PackageVersion Include="MessagePackAnalyzer" Version="3.1.7" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.9.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
@@ -40,8 +40,8 @@
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.19" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.Agents.AI" Version="1.7.0" />
-    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.9.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.4.0" />
     <PackageVersion Include="OllamaSharp" Version="5.4.25" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,7 +52,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.15.1-beta.1" />
     <PackageVersion Include="RedLock.net" Version="2.3.2" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.13.1" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/src/CasCap.Common.Abstractions/Models/CommsEvent.cs
+++ b/src/CasCap.Common.Abstractions/Models/CommsEvent.cs
@@ -29,6 +29,9 @@ public record CommsEvent
     /// </summary>
     public required DateTime TimestampUtc { get; init; }
 
+    /// <summary>The hosting environment name (e.g. Development, Test, Production) of the producer.</summary>
+    public string? Environment { get; init; }
+
     /// <summary>
     /// Optional structured JSON payload providing additional context for the agent.
     /// </summary>

--- a/src/CasCap.Common.Caching/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CasCap.Common.Caching/Extensions/ServiceCollectionExtensions.cs
@@ -44,6 +44,7 @@ public static class ServiceCollectionExtensions
         return services.AddServices(connStr, LocalCacheType,
             distributedLockingEnabled: cachingConfig.DistributedLockingEnabled,
             redisKeyFormat: cachingConfig.Redlock.RedisKeyFormat,
+            redisDatabaseId: cachingConfig.RemoteCache.DatabaseId,
             healthCheckRedis: cachingConfig.HealthCheckRedis);
     }
 
@@ -70,7 +71,8 @@ public static class ServiceCollectionExtensions
         var connStr = remoteCacheConnectionString ?? cachingConfig.RemoteCacheConnectionString;
         return services.AddServices(connStr, LocalCacheType,
             distributedLockingEnabled: cachingConfig.DistributedLockingEnabled,
-            redisKeyFormat: cachingConfig.Redlock.RedisKeyFormat);
+            redisKeyFormat: cachingConfig.Redlock.RedisKeyFormat,
+            redisDatabaseId: cachingConfig.RemoteCache.DatabaseId);
     }
 
     /// <inheritdoc cref="AddCasCapCaching(IServiceCollection, string?, CacheType)"/>
@@ -87,6 +89,7 @@ public static class ServiceCollectionExtensions
         CacheType RemoteCacheType = CacheType.Redis,
         bool distributedLockingEnabled = false,
         string redisKeyFormat = "RedLock:{0}",
+        int redisDatabaseId = 0,
         KubernetesProbeTypes healthCheckRedis = KubernetesProbeTypes.None)
     {
         //ensure RedlockConfig is always available (idempotent; won't override bound config from overload #2)
@@ -135,6 +138,7 @@ public static class ServiceCollectionExtensions
             {
                 var rlMuxer = (RedLockMultiplexer)multiplexer;
                 rlMuxer.RedisKeyFormat = redisKeyFormat;
+                rlMuxer.RedisDatabase = redisDatabaseId;
                 var redLockFactory = RedLockFactory.Create([rlMuxer]);
                 services.AddSingleton<IDistributedLockFactory>(redLockFactory);
             }

--- a/src/CasCap.Common.Extensions/Extensions/ParseExtensions.cs
+++ b/src/CasCap.Common.Extensions/Extensions/ParseExtensions.cs
@@ -100,6 +100,9 @@ public static class ParseExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int Decimal2Int(this ReadOnlySpan<char> input, int exp = 0)
     {
+        if (input.IsEmpty || input.IsWhiteSpace())
+            return 0;
+
         var decimalExists = false;
         var output = 0;
         for (var i = 0; i < input.Length; i++)
@@ -164,6 +167,9 @@ public static class ParseExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static long Decimal2Long(this ReadOnlySpan<char> input, int exp = 0)
     {
+        if (input.IsEmpty || input.IsWhiteSpace())
+            return 0L;
+
         var decimalExists = false;
         var output = 0L;
         for (var i = 0; i < input.Length; i++)


### PR DESCRIPTION
## Summary

Dependency bumps, a new `CommsEvent` property, Redis database ID pass-through for distributed locking, and a defensive guard in parse extensions.

## Changes

### NuGet Package Updates (`Directory.Packages.props`)

| Package | From | To |
| --- | --- | --- |
| Microsoft.Extensions.* (core) | 10.0.8 | 10.0.9 |
| Microsoft.Extensions.Http.Resilience | 10.6.0 | 10.7.0 |
| Microsoft.Extensions.AI* | 10.6.0 | 10.7.0 |
| Microsoft.Agents.AI* | 1.7.0 | 1.9.0 |
| MessagePack* | 3.1.6 | 3.1.7 |
| ModelContextProtocol | 1.3.0 | 1.4.0 |
| StackExchange.Redis | 2.13.1 | 2.13.17 |

### CommsEvent: `Environment` property (`CasCap.Common.Abstractions`)

Added an optional `Environment` property to `CommsEvent` to capture the hosting environment name (e.g. Development, Test, Production) of the producer.

### Caching: Redis database ID support (`CasCap.Common.Caching`)

The `AddServices` helper now passes `cachingConfig.RemoteCache.DatabaseId` through to `RedLockMultiplexer.RedisDatabase`, allowing Redlock to target a specific Redis database index rather than always defaulting to 0.

### ParseExtensions: empty/whitespace guard (`CasCap.Common.Extensions`)

`Decimal2Int` and `Decimal2Long` (`ReadOnlySpan<char>` overloads) now return 0 early when the input is empty or whitespace, preventing potential index/parsing issues on malformed data.