### PR TITLE
Add optional basic-auth support to OTLP exporters

### DIFF
--- a/src/CasCap.Common.OpenTelemetry/CasCap.Common.OpenTelemetry.csproj
+++ b/src/CasCap.Common.OpenTelemetry/CasCap.Common.OpenTelemetry.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\CasCap.Common.Abstractions\CasCap.Common.Abstractions.csproj" />
     <ProjectReference Include="..\CasCap.Common.Logging.Serilog\CasCap.Common.Logging.Serilog.csproj" />
+    <ProjectReference Include="..\CasCap.Common.Net\CasCap.Common.Net.csproj" />
     <ProjectReference Include="..\CasCap.Common.Services\CasCap.Common.Services.csproj" />
   </ItemGroup>
 

--- a/src/CasCap.Common.OpenTelemetry/Extensions/OpenTelemetryExtensions.cs
+++ b/src/CasCap.Common.OpenTelemetry/Extensions/OpenTelemetryExtensions.cs
@@ -11,6 +11,7 @@ public static class OpenTelemetryExtensions
     /// <param name="metricsConfig">Metrics configuration providing service name, metric prefix, and OTLP endpoint.</param>
     /// <param name="gitMetadata">Git metadata for resource attributes.</param>
     /// <param name="connectionMultiplexer">Optional Redis connection multiplexer for trace instrumentation.</param>
+    /// <param name="apiAuthConfig">Optional basic-auth credentials applied as an <c>Authorization</c> header on every OTLP export — required only when the collector endpoint sits behind an authenticating ingress.</param>
     /// <param name="configureMetrics">Optional callback to add app-specific metrics configuration.</param>
     /// <param name="configureTracing">Optional callback to add app-specific tracing configuration.</param>
     public static void InitializeOpenTelemetry(
@@ -18,6 +19,7 @@ public static class OpenTelemetryExtensions
         IMetricsConfig metricsConfig,
         GitMetadata gitMetadata,
         IConnectionMultiplexer? connectionMultiplexer = null,
+        ApiAuthConfig? apiAuthConfig = null,
         Action<MeterProviderBuilder>? configureMetrics = null,
         Action<TracerProviderBuilder>? configureTracing = null)
     {
@@ -28,6 +30,25 @@ public static class OpenTelemetryExtensions
         }
 
         var otlpEndpoint = metricsConfig.OtlpExporterEndpoint;
+
+        // Build an OTLP Authorization header (gRPC metadata / HTTP header) from the shared basic-auth
+        // credentials. Only needed when exporting through an authenticating ingress; in-cluster exports
+        // straight to the collector service ignore it harmlessly.
+        string? otlpHeaders = null;
+        if (apiAuthConfig is not null
+            && !string.IsNullOrWhiteSpace(apiAuthConfig.Username)
+            && !string.IsNullOrWhiteSpace(apiAuthConfig.Password))
+        {
+            otlpHeaders = $"Authorization={NetExtensions.GetBasicAuthHeaderValue(apiAuthConfig.Username, apiAuthConfig.Password)}";
+        }
+
+        void ConfigureOtlpExporter(OtlpExporterOptions opt)
+        {
+            opt.Protocol = OtlpExportProtocol.Grpc;
+            opt.Endpoint = otlpEndpoint;
+            if (otlpHeaders is not null)
+                opt.Headers = otlpHeaders;
+        }
 
         var attributes = new Dictionary<string, object>
         {
@@ -52,11 +73,7 @@ public static class OpenTelemetryExtensions
                     metricsBuilder.AddProcessInstrumentation();
                 }
                 configureMetrics?.Invoke(metricsBuilder);
-                metricsBuilder.AddOtlpExporter(opt =>
-                {
-                    opt.Protocol = OtlpExportProtocol.Grpc;
-                    opt.Endpoint = otlpEndpoint;
-                });
+                metricsBuilder.AddOtlpExporter(ConfigureOtlpExporter);
             })
             .WithTracing(tracingBuilder =>
             {
@@ -77,20 +94,12 @@ public static class OpenTelemetryExtensions
                 if (!builder.Environment.IsDevelopment() && connectionMultiplexer is not null)
                     tracingBuilder.AddRedisInstrumentation(connectionMultiplexer, configure => { });
                 configureTracing?.Invoke(tracingBuilder);
-                tracingBuilder.AddOtlpExporter(opt =>
-                {
-                    opt.Protocol = OtlpExportProtocol.Grpc;
-                    opt.Endpoint = otlpEndpoint;
-                });
+                tracingBuilder.AddOtlpExporter(ConfigureOtlpExporter);
             })
             .WithLogging(loggingBuilder =>
             {
                 loggingBuilder.SetResourceBuilder(resourceBuilder);
-                loggingBuilder.AddOtlpExporter(opt =>
-                {
-                    opt.Protocol = OtlpExportProtocol.Grpc;
-                    opt.Endpoint = otlpEndpoint;
-                });
+                loggingBuilder.AddOtlpExporter(ConfigureOtlpExporter);
             });
     }
 }


### PR DESCRIPTION
## Summary

Adds optional basic-auth support to the OTLP exporters configured by `InitializeOpenTelemetry`, so telemetry can be exported through an authenticating ingress.

## Changes

- **`OpenTelemetryExtensions.InitializeOpenTelemetry`**: added an optional `ApiAuthConfig? apiAuthConfig` parameter. When username and password are supplied, an `Authorization` header (built via `NetExtensions.GetBasicAuthHeaderValue`) is applied to every OTLP export (metrics, tracing, and logging).
- Extracted the duplicated OTLP exporter setup into a single `ConfigureOtlpExporter` helper that sets the gRPC protocol, endpoint, and (when present) the auth headers — replacing the three near-identical inline exporter configurations.
- Added a `ProjectReference` to `CasCap.Common.Net` for access to `NetExtensions.GetBasicAuthHeaderValue`.

## Notes

- The auth header is only required when exporting through an authenticating ingress; in-cluster exports straight to the collector service ignore it harmlessly.
- The new parameter is optional and defaults to `null`, so existing callers are unaffected.
