### PR TITLE
2026-06 updates: graceful cache-expiry shutdown, runtime console log switch, MessagePack buffer overload & NuGet bumps

### DIFF
--- a/.github/instructions/csharp.instructions.md
+++ b/.github/instructions/csharp.instructions.md
@@ -7,7 +7,11 @@ applyTo: '**/*.cs'
 
 ## Style (enforced by `.editorconfig`)
 
-- **Class-per-file**: Each top-level type (class, `static class`, record, struct, interface, enum) lives in its own file named after the type (`MyService.cs` for `class MyService`; `FooConstants.cs` for `static class FooConstants`). Exempt: nested private types; enums (consolidate per-project into one `_Enums.cs`); `IAppConfig` implementations and their nested config classes (underscore-prefixed filename, e.g. `_AppConfig.cs` for `record AppConfig`, to group config files at the top of the explorer — the underscore is not part of the type name). **Generic types**: encode type parameters with curly braces — `Foo{T}.cs`, `Bar{T,U}.cs`, `_FeatureConfig{T}.cs` (Microsoft .NET runtime convention).
+- **Class-per-file (one top-level type per file — strict)**: Every top-level type — `class`, `static class`, `record`, `record struct`, `struct`, `interface`, `enum` — lives in its **own** file named after the type (`MyService.cs` for `class MyService`; `FooConstants.cs` for `static class FooConstants`). **Never place two top-level types in the same file.** The *only* types allowed to share a file with another type are **nested types** (types declared inside another type, at any accessibility). If you are about to add a second top-level type to an existing file, stop and create a new file instead. There are exactly two grouping exceptions, both signalled by an underscore-prefixed filename (the underscore is not part of any type name):
+  - **`_Enums.cs`** — consolidates every `enum` in a project into one file (enums only; this is the one file permitted to hold multiple top-level types).
+  - **`_*Config.cs`** (e.g. `_AppConfig.cs` for `record AppConfig`) — groups an `IAppConfig` implementation with its related config types, to keep config files at the top of the explorer.
+
+  **Generic types** are not an exception to the one-type rule; they only change the filename — encode type parameters with curly braces: `Foo{T}.cs`, `Bar{T,U}.cs`, `_FeatureConfig{T}.cs` (Microsoft .NET runtime convention).
 - **Indentation**: 4 spaces, LF line endings, insert final newline
 - **Interfaces**: Must start with `I` (PascalCase) and live in an Abstractions folder and an Abstractions namespace.
 - **Types/Methods/Properties**: PascalCase
@@ -21,7 +25,9 @@ applyTo: '**/*.cs'
 - **Async pass-through**: When a method is a thin wrapper that only returns another async call (no `using`, `try`/`catch`, or additional `await`s), drop `async`/`await` and return the `Task`/`ValueTask` directly to avoid unnecessary state-machine overhead.
 - **Async/Await**: Always await async method calls.
 - **Pattern matching**: Preferred (`is`, `not`, switch expressions)
-- **Primary constructors**: Preferred (`csharp_style_prefer_primary_constructors = true`). Use parameters directly in the class body — do **not** copy them to private/protected fields (avoid `private ILogger _logger = logger;`). **Exception**: abstract base classes may expose a `protected` field for inheritors (`protected ILogger _logger = logger;` with `: base(logger)`). Access `IOptions<T>` / `IOptionsMonitor<T>` via `.Value` / `.CurrentValue` inline, not cached. Wrap long parameter lists one-per-line, with the closing parenthesis and base/interface clause on their own line.
+- **Primary constructors**: Preferred (`csharp_style_prefer_primary_constructors = true`). Use parameters directly in the class body — do **not** copy them to private/protected fields (avoid `private ILogger _logger = logger;`). **Exception**: abstract base classes may expose a `protected` field for inheritors (`protected ILogger _logger = logger;` with `: base(logger)`).
+- **`IOptions<T>` access**: Read `IOptions<T>` / `IOptionsMonitor<T>` values via `.Value` / `.CurrentValue` inline at the point of use — do **not** copy them into a private/protected field or a cached local.
+- **Wrapping long parameter lists**: When a constructor or method parameter list is too long for a single line, wrap it one parameter per line, with the closing parenthesis (and any `: base(...)` / interface clause) on its own line.
 - **`var`**: Preferred — use `var` unless the type is not obvious from the right-hand side
 - **Records**: Prefer `record` types with `get; init;` properties over classes where object comparison semantics are useful
 - **Constructors**: When injecting services use a 'Svc' suffix on the parameter name and its private field instead of 'Service' to make more concise.

--- a/.gitignore
+++ b/.gitignore
@@ -367,3 +367,6 @@ FodyWeavers.xsd
 !.docker/redis.conf
 .vscode/*
 !.vscode/extensions.json
+
+# HVE / Copilot runtime artefacts
+.copilot-tracking/

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,7 @@
     <PackageVersion Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
-    <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.1" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.1.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="MessagePackAnalyzer" Version="3.1.7" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.10.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.11.1" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
@@ -24,7 +24,7 @@
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Enrichers.AssemblyName" Version="2.0.0" />
@@ -39,19 +39,19 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.Agents.AI" Version="1.10.0" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.11.1" />
     <PackageVersion Include="ModelContextProtocol" Version="1.4.0" />
     <PackageVersion Include="OllamaSharp" Version="5.4.25" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.15.1-beta.1" />
     <PackageVersion Include="RedLock.net" Version="2.3.2" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
+    <PackageVersion Include="StackExchange.Redis" Version="3.0.7" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/CasCap.Common.Caching/Services/LocalCacheExpiryService.cs
+++ b/src/CasCap.Common.Caching/Services/LocalCacheExpiryService.cs
@@ -28,11 +28,13 @@ public sealed class LocalCacheExpiryService(ILogger<LocalCacheExpiryService> log
                 ExpireByKey(key);
         });
 
-        //keep alive
-        while (!cancellationToken.IsCancellationRequested)
+        //keep alive until cancellation is requested; the expected cancellation must not surface as an exception so the
+        //unsubscribe/housekeeping below still runs on a graceful shutdown.
+        try
         {
-            await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
         }
+        catch (OperationCanceledException) { }
 
         logger.LogDebug("{ClassName} unsubscribing from {ObjectType} name {ChannelName}, {PropertyName}={IsPattern}",
             nameof(LocalCacheExpiryService), typeof(RedisChannel), channelName, nameof(RedisChannel.IsPattern), channel.IsPattern);

--- a/src/CasCap.Common.Caching/Services/RemoteCacheExpiryService.cs
+++ b/src/CasCap.Common.Caching/Services/RemoteCacheExpiryService.cs
@@ -27,11 +27,13 @@ public sealed class RemoteCacheExpiryService(ILogger<RemoteCacheExpiryService> l
                 nameof(RemoteCacheExpiryService), key, success, remoteCache.SlidingExpirations.Count);
         }).ConfigureAwait(false);
 
-        //keep alive
-        while (!cancellationToken.IsCancellationRequested)
+        //keep alive until cancellation is requested; the expected cancellation must not surface as an exception so the
+        //unsubscribe/housekeeping below still runs on a graceful shutdown.
+        try
         {
-            await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
         }
+        catch (OperationCanceledException) { }
 
         logger.LogDebug("{ClassName} unsubscribing from {ObjectType} name {ChannelName}, {PropertyName}={IsPattern}",
             nameof(RemoteCacheExpiryService), typeof(RedisChannel), channelName, nameof(RedisChannel.IsPattern), channel.IsPattern);

--- a/src/CasCap.Common.Logging.Serilog/Extensions/SerilogExtensions.cs
+++ b/src/CasCap.Common.Logging.Serilog/Extensions/SerilogExtensions.cs
@@ -11,6 +11,14 @@ public static class SerilogExtensions
     private static bool _bootstrapLoggerInitialized;
 
     /// <summary>
+    /// Controls the verbosity of the console sink at runtime. Defaults to <see cref="LogEventLevel.Verbose"/> so the
+    /// console mirrors the configured pipeline level. Interactive console apps (e.g. a full-screen Spectre UI) can
+    /// raise this to <see cref="LogEventLevel.Warning"/> or higher once startup completes to stop log lines
+    /// interleaving with rendered output, without affecting the file/Seq/Loki sinks.
+    /// </summary>
+    public static readonly Core.LoggingLevelSwitch ConsoleLevelSwitch = new(LogEventLevel.Verbose);
+
+    /// <summary>
     /// Creates a bootstrap <see cref="Log.Logger"/> with a platform-aware console sink
     /// and wires it into <see cref="ApplicationLogging.LoggerFactory"/>.
     /// Call this early in <c>Program.cs</c> before the DI container is built.
@@ -28,7 +36,8 @@ public static class SerilogExtensions
                     theme: RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                         ? SystemConsoleTheme.Literate
                         : AnsiConsoleTheme.Code,
-                    applyThemeToRedirectedOutput: true)
+                    applyThemeToRedirectedOutput: true,
+                    levelSwitch: ConsoleLevelSwitch)
                 .CreateBootstrapLogger();
 
             ApplicationLogging.LoggerFactory = new SerilogLoggerFactory(Log.Logger);
@@ -57,7 +66,8 @@ public static class SerilogExtensions
                 theme: RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                     ? SystemConsoleTheme.Literate
                     : AnsiConsoleTheme.Code,
-                applyThemeToRedirectedOutput: true)
+                applyThemeToRedirectedOutput: true,
+                levelSwitch: ConsoleLevelSwitch)
             .Enrich.FromLogContext()
             .Enrich.WithEnvironmentName()
             .Enrich.WithEnvironmentUserName()

--- a/src/CasCap.Common.Logging.Serilog/README.md
+++ b/src/CasCap.Common.Logging.Serilog/README.md
@@ -22,6 +22,17 @@ Provides a bootstrap logger for early startup logging and a composable `AddCasCa
 | `SerilogWebApplicationBuilderExtensions.InitializeSerilog(builder, categoryName)` | Thread-safe one-shot Serilog initialization on a `WebApplicationBuilder` via `UseSerilog` + `AddCasCapDefaults` |
 | `LoggerConfiguration.AddCasCapDefaults(IConfiguration)` | Applies standard enrichers, console sink, health-check filter, and config binding |
 
+### Runtime Console Control
+
+`SerilogExtensions.ConsoleLevelSwitch` is a static `LoggingLevelSwitch` wired into the console sink (both the bootstrap logger and `AddCasCapDefaults`). It defaults to `Verbose` so the console mirrors the configured pipeline level. Interactive console apps (e.g. a full-screen Spectre UI) can raise it to `Warning` or higher once startup completes to stop log lines interleaving with rendered output, without affecting the file/Seq/Loki sinks.
+
+```csharp
+var previous = SerilogExtensions.ConsoleLevelSwitch.MinimumLevel;
+SerilogExtensions.ConsoleLevelSwitch.MinimumLevel = LogEventLevel.Warning;
+try { /* run the interactive UI */ }
+finally { SerilogExtensions.ConsoleLevelSwitch.MinimumLevel = previous; }
+```
+
 ### Enrichers Included
 
 `FromLogContext`, `WithEnvironmentName`, `WithEnvironmentUserName`, `WithProcessId`, `WithThreadId`, `WithExceptionDetails`, `WithAssemblyName`, `WithSpan`

--- a/src/CasCap.Common.Serialization.MessagePack/Extensions/MessagePackExtensions.cs
+++ b/src/CasCap.Common.Serialization.MessagePack/Extensions/MessagePackExtensions.cs
@@ -27,7 +27,8 @@ public static class MessagePackExtensions
     public static T FromMessagePack<T>(this byte[] bytes)
     {
         bytes = bytes ?? throw new ArgumentNullException(paramName: nameof(bytes));
-        return bytes.AsMemory().FromMessagePack<T>();
+        ReadOnlyMemory<byte> buffer = bytes;
+        return buffer.FromMessagePack<T>();
     }
 
     /// <summary>Deserializes a MessagePack buffer to an instance of <typeparamref name="T"/>.</summary>

--- a/src/CasCap.Common.Serialization.MessagePack/Extensions/MessagePackExtensions.cs
+++ b/src/CasCap.Common.Serialization.MessagePack/Extensions/MessagePackExtensions.cs
@@ -27,6 +27,16 @@ public static class MessagePackExtensions
     public static T FromMessagePack<T>(this byte[] bytes)
     {
         bytes = bytes ?? throw new ArgumentNullException(paramName: nameof(bytes));
+        return bytes.AsMemory().FromMessagePack<T>();
+    }
+
+    /// <summary>Deserializes a MessagePack buffer to an instance of <typeparamref name="T"/>.</summary>
+    /// <remarks>
+    /// Buffer overload for transport-neutral callers (e.g. snapshot/gRPC payloads) that already hold a
+    /// <see cref="ReadOnlyMemory{T}"/> slice and want to avoid an intermediate <see cref="byte"/> array copy.
+    /// </remarks>
+    public static T FromMessagePack<T>(this ReadOnlyMemory<byte> bytes)
+    {
         try
         {
             T obj = MessagePackSerializer.Deserialize<T>(bytes);


### PR DESCRIPTION
## Summary

Maintenance round for CasCap.Common: hardens the Redis cache-expiry background services against shutdown exceptions, adds runtime console-log verbosity control for interactive console apps, adds a zero-copy MessagePack deserialization overload, refreshes NuGet dependencies (notably StackExchange.Redis to v3), and clarifies the class-per-file coding convention.

## Changes

### Caching — graceful shutdown
- `LocalCacheExpiryService` / `RemoteCacheExpiryService`: replaced the busy-wait keep-alive loop (`while (!cancellationToken.IsCancellationRequested) await Task.Delay(...)`) with a single `await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken)` wrapped in a `try/catch (OperationCanceledException)`. The expected cancellation no longer surfaces as an exception, so the unsubscribe/housekeeping logic still runs on a graceful shutdown — and we drop the 100 ms / 1000 ms polling.

### Logging — runtime console verbosity control
- `SerilogExtensions.ConsoleLevelSwitch`: new static `LoggingLevelSwitch` (default `Verbose`) wired into the console sink of both the bootstrap logger and `AddCasCapDefaults`. Interactive console apps (e.g. a full-screen Spectre UI) can raise it to `Warning`+ once startup completes to stop log lines interleaving with rendered output, without affecting the file/Seq/Loki sinks.
- Documented in `CasCap.Common.Logging.Serilog/README.md` with a usage snippet.

### Serialization — MessagePack buffer overload
- Added `FromMessagePack<T>(this ReadOnlyMemory<byte> bytes)` for transport-neutral callers (snapshot/gRPC payloads) that already hold a buffer slice and want to avoid an intermediate `byte[]` copy. The existing `byte[]` overload now delegates to it.

### Dependencies
| Package | From | To |
| --- | --- | --- |
| Microsoft.Agents.AI | 1.10.0 | 1.11.1 |
| Microsoft.Agents.AI.Workflows | 1.10.0 | 1.11.1 |
| Microsoft.NET.Test.Sdk | 18.6.0 | 18.7.0 |
| Serilog.Settings.Configuration | 10.0.0 | 10.0.1 |
| OpenTelemetry.Instrumentation.AspNetCore | 1.15.2 | 1.16.0 |
| OpenTelemetry.Instrumentation.Http | 1.15.1 | 1.16.0 |
| **StackExchange.Redis** | **2.13.17** | **3.0.7** ⚠️ major |

### Conventions & tooling
- `.github/instructions/csharp.instructions.md`: clarified the **one top-level type per file** rule (strict, with the two underscore-prefixed grouping exceptions `_Enums.cs` / `_*Config.cs`), split `IOptions<T>` access and long-parameter-list wrapping into their own explicit bullets.
- `.gitignore`: ignore `.copilot-tracking/` runtime artefacts.

## Risk / Notes
- **StackExchange.Redis 3.0** is a major version bump — worth a smoke test against the caching integration tests before merge.
- No public API removals; the MessagePack change is purely additive.

## Commits
- `2de9b93` FromMessagePack ext added
- `b995e93` keep alive fix
- `3d06763` canx exception fix 2
- `309b19e` added ConsoleLevelSwitch
- `36b7cdc` / `46d1987` / `a8c10e0` nuget updates & fixes
- `547dd59` make instructions clearer
- `f34310b` .copilot-tracking tidy up