### PR TITLE
Sync shared instructions: bash scripting conventions and GitHub Actions script-extraction requirement

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,7 @@ Detailed conventions live in scoped instruction files under `.github/instruction
 | `csharp.azure.instructions.md` | `**/*.cs` | Azure Table Storage & Redis key naming |
 | `dotnet.instructions.md` | `**/*.csproj`, `*.slnx`, `Directory.*.props` | Central build/package config, solution format, SDK pinning |
 | `github-actions.instructions.md` | workflows / `action.yml` | GitHub Actions naming, YAML, security, GitVersion |
+| `bash.instructions.md` | `**/*.sh` | Bash scripting structure, error handling, logging, testability |
 | `documentation.instructions.md` | `**/*.md` | README consistency & Mermaid diagrams |
 | `configuration.instructions.md` | `**/appsettings*.json` | `IAppConfig` / appsettings sync |
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,7 @@ updates:
       time: "04:00"
     open-pull-requests-limit: 10
     ignore:
+      #xunit.v3 majors are migrations, not bumps: 3.x to 4.0 forced Microsoft.Testing.Platform,
+      #OutputType Exe and four package swaps. Minors and patches flow normally.
       - dependency-name: xunit.*
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,4 @@ updates:
       time: "04:00"
     open-pull-requests-limit: 10
     ignore:
-      - dependency-name: coverlet.*
-      - dependency-name: Microsoft.NET.Test.Sdk
       - dependency-name: xunit.*

--- a/.github/instructions/bash.instructions.md
+++ b/.github/instructions/bash.instructions.md
@@ -1,0 +1,53 @@
+---
+description: 'Bash scripting conventions — structure, error handling, logging and testability.'
+applyTo: '**/*.sh'
+---
+
+# Bash / Shell Scripts
+
+## Structure
+
+- **Shebang**: `#!/usr/bin/env bash` (not `#!/bin/bash`) — resolves bash via `PATH` rather than assuming it lives at `/bin/bash`.
+- **Header comment**: Every script opens with a short comment block stating what it does and, when it's invoked from a GitHub Actions composite step, a `# Required environment variables: X, Y, Z` line (plus a note on which are optional). This is the script's contract — a reader shouldn't need to open the calling `action.yml` to know what it needs.
+- **Location**: Non-trivial or GitHub Actions composite-action scripts live in a dot-prefixed `.scripts/` folder at the repository (or action) root, per `github-actions.instructions.md`.
+- **Executable bit**: Set `chmod +x` on any script invoked directly by path (e.g. `run: "${{ github.action_path }}/.scripts/name.sh"`) rather than via `bash script.sh`. **Gotcha**: this container's `git config core.fileMode` is `false`, so `git add` on a newly created file does not pick up a `chmod +x` applied before staging. Verify with `git ls-files -s path/to/script.sh` shows `100755`; if it shows `100644`, fix it with `git update-index --chmod=+x path/to/script.sh` before committing.
+- **Exemption — manual/interactive runbooks**: A script meant to be read and run step-by-step by a human (contains `sudo reboot`, `sudo nano`, or similar interactive/destructive steps) is exempt from the automation conventions below. Mark it as such in its header comment (e.g. `# Run manually, step by step — not intended for unattended execution.`) so it isn't mistaken for broken automation.
+
+## Error Handling
+
+- **Validate required environment variables before enabling strict mode**, so a missing variable produces one clear, intentional error instead of bash's raw "unbound variable" trace:
+
+  ```bash
+  # Validate required environment variables before enabling strict mode
+  for var in FOO BAR BAZ; do
+    if [[ -z "${!var:-}" ]]; then
+      echo "::error::Required environment variable $var is not set."
+      exit 1
+    fi
+  done
+
+  set -euo pipefail
+  ```
+
+- **`set -euo pipefail`** is required in every automation script (exit on error, exit on unset variable, fail a pipeline on any stage's non-zero exit), placed immediately after the required-variable validation loop above.
+- **Default optional variables explicitly** before `set -u` takes effect, using `: "${VAR:=}"` (or a per-use `"${VAR:-}"`), so referencing an optional, legitimately-unset variable doesn't crash the script.
+- **Quote every variable expansion** (`"$var"`, `"${arr[@]}"`) unless intentional word-splitting/globbing is required — this includes file paths, which may contain spaces.
+- **Fail fast with a specific message** rather than letting an empty/invalid value propagate into a downstream command's cryptic error (e.g. validate chart registry credentials before calling `helm pull`, not after it fails).
+
+## Logging & GitHub Actions Annotations
+
+- Use `::error::message` (or `::error file=$FILE::message` when a specific file is implicated) for failures, `::warning title=X::message` for non-fatal issues, and `::add-mask::$value` for any secret obtained or derived *at runtime* (an exchanged token, a short-lived API key) — not just secrets passed in as inputs.
+- Log plain progress/diagnostic lines with `echo`; prefer one `echo` per line over `printf "\n...` continuation chains for readability of the raw log.
+- Never `echo`/log a secret value in full — redact it (e.g. `echo "CHART_REGISTRY_PASSWORD=***"`) or rely on `::add-mask::`.
+
+## Testability
+
+- **A script extracted per `github-actions.instructions.md`'s Composite Actions guidance must be runnable and testable standalone**, without a live Actions run. Depend only on the documented environment variables — nothing implicit from the Actions runtime beyond `GITHUB_ENV`/`GITHUB_OUTPUT` (which can be pointed at a temp file locally).
+- **Mock external commands** (`curl`, `helm`, `git`, cloud CLIs) for local testing by placing a stub executable earlier on `PATH` rather than hitting real endpoints or requiring live credentials. Exercise the success path and every distinct error path (missing required variable, empty/invalid response, etc.).
+- Run `shellcheck` against new or modified scripts before committing; treat anything above informational severity as worth fixing (an informational `SC2016` on an intentionally single-quoted `yq`/`jq` expression, for example, is expected and can be left as-is).
+
+## Style
+
+- **`local`** every function-scoped variable.
+- Lowercase values that feed case-sensitive downstream systems expecting lowercase (OCI registries/repositories) with `${var,,}`.
+- Clean up any temporary file/directory a script creates, even when it runs in a loop (each iteration's temp artifacts must not leak into the next).

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -64,7 +64,8 @@ applyTo: '.github/workflows/**,.github/actions/**,**/action.yml,**/action.yaml'
 ## Composite Actions
 
 - Declare `shell: bash` explicitly on every `run` step — composite actions do not inherit a default shell.
-- Reference scripts relative to the action root using `${{ github.action_path }}/scripts/name.sh`.
+- Reference scripts relative to the action root using `${{ github.action_path }}/.scripts/name.sh`.
+- **Extract sizeable or critical `run` logic into an external script** under `.scripts/` (e.g. `.scripts/check-release-exists.sh`, `.scripts/Invoke-CheckReleaseExists.ps1`) rather than inlining it in the composite action YAML. An external script can be run and tested standalone — locally or from a `.github/workflows/test.yml` — before it's ever exercised by a real Actions run; a `run: |` block embedded in YAML cannot be. Keep genuinely trivial one-liners inline.
 
 ## Security
 

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -24,6 +24,20 @@ applyTo: '.github/workflows/**,.github/actions/**,**/action.yml,**/action.yaml'
 - **Environment variables**: ALL_UPPERCASE with underscores (e.g. `IMAGE_REGISTRY`, `TAG_OVERRIDE`, `MANIFEST_PATHS`).
 - **Secrets**: ALL_UPPERCASE with underscores (e.g. `GITHUB_TOKEN`, `GH_PAT_GITOPS`, `NUGET_API_KEY`).
 
+## Descriptions
+
+- **Keep every `description:` to one short line.** It states what the value *is*, not how or why to use it. Prefer `e.g. <example>` over prose describing the format.
+- **Move rationale, caveats, deprecation notices and cross-references into a `#` comment directly above the input**, not into the description string. Use the repo's `#no-space-after-hash` comment style.
+- Avoid multi-sentence descriptions — they bloat the file and make the input list hard to scan.
+- Keeping `key: value` pairs out of descriptions also avoids the colon-space sequence that would otherwise force the whole scalar to be quoted.
+
+  ```yaml
+  #DEPRECATED, superseded by nuget-user (Trusted Publishing). Ignored when nuget-user is set.
+  NUGET_API_KEY:
+    description: Long-lived NuGet API key e.g. secrets.NUGET_API_KEY
+    type: string
+  ```
+
 ## YAML Style
 
 - **2-space indentation** for all workflow and action YAML files.

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -27,6 +27,7 @@ applyTo: '.github/workflows/**,.github/actions/**,**/action.yml,**/action.yaml'
 ## Descriptions
 
 - **Keep every `description:` to one short line.** It states what the value *is*, not how or why to use it. Prefer `e.g. <example>` over prose describing the format.
+- **Applies to workflow inputs (`workflow_dispatch`, `workflow_call`) as well as action inputs.** `workflow_dispatch` descriptions render as field labels in the *Run workflow* dialog, where a long sentence wraps and makes the form look messy.
 - **Move rationale, caveats, deprecation notices and cross-references into a `#` comment directly above the input**, not into the description string. Use the repo's `#no-space-after-hash` comment style.
 - Avoid multi-sentence descriptions — they bloat the file and make the input list hard to scan.
 - Keeping `key: value` pairs out of descriptions also avoids the colon-space sequence that would otherwise force the whole scalar to be quoted.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,19 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
+#Deny all by default; each job grants only the scopes it needs.
+permissions: {}
+
 jobs:
   lint:
     if: github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+    permissions:
+      contents: read #checkout
     uses: f2calv/gha-workflows/.github/workflows/lint.yml@v1
 
   versioning:
+    permissions:
+      contents: read #checkout and release lookup
     uses: f2calv/gha-workflows/.github/workflows/gha-release-versioning.yml@v1
     with:
       tag-prefix: ''
@@ -49,6 +56,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [versioning]
+    #Note: a permissions block is subtractive - every scope not listed resets to none.
+    #The composite action cannot request these itself, so they must be declared here.
+    permissions:
+      id-token: write #OIDC token for NuGet Trusted Publishing
+      contents: read #checkout
+      packages: write #push to nuget.pkg.github.com
     services:
       redis:
         image: redis
@@ -58,13 +71,18 @@ jobs:
       - uses: f2calv/gha-dotnet-nuget@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          #The nuget.org username matches the GitHub owner. If they ever diverge this must
+          #become a literal, or the token exchange fails with an opaque 401.
+          nuget-user: ${{ github.repository_owner }}
           configuration: ${{ inputs.configuration }}
           execute-tests: ${{ inputs.execute-tests }}
           push-preview: ${{ inputs.push-preview }}
           package-filter: ${{ inputs.package-filter }}
           version: ${{ needs.versioning.outputs.version }}
-          dotnet-test-args: --maxcpucount:1 #Note: disable parallel test execution due to InlineData and Redis ClearOnStartup property
+          #Serialises test modules so the shared Redis instance is not clobbered by the ClearOnStartup
+          #cases. This replaces the MSBuild-era --maxcpucount:1, which under Microsoft.Testing.Platform
+          #makes discovery report "Zero tests ran" and exit 5. Verified locally by bisection.
+          dotnet-test-args: --max-parallel-test-modules 1
 
   release:
     needs: [versioning, build]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
-    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
+    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.2" />
     <PackageVersion Include="MessagePack" Version="3.1.8" />
     <PackageVersion Include="MessagePackAnalyzer" Version="3.1.8" />
     <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.17.0" />
@@ -39,7 +39,7 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.1.0" />
     <PackageVersion Include="Microsoft.Agents.AI" Version="1.17.0" />
-    <PackageVersion Include="ModelContextProtocol" Version="2.1.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="2.2.0" />
     <PackageVersion Include="OllamaSharp" Version="5.4.30" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.9.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />
     <PackageVersion Include="Serilog" Version="4.4.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Enrichers.AssemblyName" Version="2.0.0" />
@@ -51,10 +51,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.15.1-beta.1" />
     <PackageVersion Include="RedLock.net" Version="2.3.2" />
     <PackageVersion Include="StackExchange.Redis" Version="3.1.13" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
-    <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,8 @@
 {
     "sdk": {
         "allowPrerelease": false
+    },
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
     }
 }

--- a/src/CasCap.Common.Caching.Tests/CasCap.Common.Caching.Tests.csproj
+++ b/src/CasCap.Common.Caching.Tests/CasCap.Common.Caching.Tests.csproj
@@ -15,20 +15,8 @@
     <ProjectReference Include="..\CasCap.Common.Testing\CasCap.Common.Testing.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.msbuild">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
   </ItemGroup>
 
 </Project>

--- a/src/CasCap.Common.Caching.Tests/README.md
+++ b/src/CasCap.Common.Caching.Tests/README.md
@@ -16,11 +16,8 @@ Verifies the multi-tier caching infrastructure — Memory, Disk, and Redis cache
 
 | Package |
 | --- |
-| [Microsoft.NET.Test.Sdk](https://www.nuget.org/packages/microsoft.net.test.sdk) |
 | [xunit.v3](https://www.nuget.org/packages/xunit.v3) |
-| [xunit.runner.visualstudio](https://www.nuget.org/packages/xunit.runner.visualstudio) |
-| [coverlet.collector](https://www.nuget.org/packages/coverlet.collector) |
-| [coverlet.msbuild](https://www.nuget.org/packages/coverlet.msbuild) |
+| [Microsoft.Testing.Extensions.CodeCoverage](https://www.nuget.org/packages/microsoft.testing.extensions.codecoverage) |
 
 ### Project References
 

--- a/src/CasCap.Common.Extensions.Tests/CasCap.Common.Extensions.Tests.csproj
+++ b/src/CasCap.Common.Extensions.Tests/CasCap.Common.Extensions.Tests.csproj
@@ -11,20 +11,8 @@
     <ProjectReference Include="..\CasCap.Common.Testing\CasCap.Common.Testing.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.msbuild">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
   </ItemGroup>
 
 </Project>

--- a/src/CasCap.Common.Extensions.Tests/README.md
+++ b/src/CasCap.Common.Extensions.Tests/README.md
@@ -14,11 +14,8 @@ Verifies general-purpose extension methods — enum helpers, parsing utilities, 
 
 | Package |
 | --- |
-| [Microsoft.NET.Test.Sdk](https://www.nuget.org/packages/microsoft.net.test.sdk) |
 | [xunit.v3](https://www.nuget.org/packages/xunit.v3) |
-| [xunit.runner.visualstudio](https://www.nuget.org/packages/xunit.runner.visualstudio) |
-| [coverlet.collector](https://www.nuget.org/packages/coverlet.collector) |
-| [coverlet.msbuild](https://www.nuget.org/packages/coverlet.msbuild) |
+| [Microsoft.Testing.Extensions.CodeCoverage](https://www.nuget.org/packages/microsoft.testing.extensions.codecoverage) |
 
 ### Project References
 

--- a/src/CasCap.Common.Net.Tests/CasCap.Common.Net.Tests.csproj
+++ b/src/CasCap.Common.Net.Tests/CasCap.Common.Net.Tests.csproj
@@ -11,20 +11,8 @@
     <ProjectReference Include="..\CasCap.Common.Testing\CasCap.Common.Testing.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.msbuild">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
   </ItemGroup>
 
 </Project>

--- a/src/CasCap.Common.Net.Tests/README.md
+++ b/src/CasCap.Common.Net.Tests/README.md
@@ -14,11 +14,8 @@ Verifies HTTP client base class behaviour and network extension methods — head
 
 | Package |
 | --- |
-| [Microsoft.NET.Test.Sdk](https://www.nuget.org/packages/microsoft.net.test.sdk) |
 | [xunit.v3](https://www.nuget.org/packages/xunit.v3) |
-| [xunit.runner.visualstudio](https://www.nuget.org/packages/xunit.runner.visualstudio) |
-| [coverlet.collector](https://www.nuget.org/packages/coverlet.collector) |
-| [coverlet.msbuild](https://www.nuget.org/packages/coverlet.msbuild) |
+| [Microsoft.Testing.Extensions.CodeCoverage](https://www.nuget.org/packages/microsoft.testing.extensions.codecoverage) |
 
 ### Project References
 

--- a/src/CasCap.Common.Serialization.Tests/CasCap.Common.Serialization.Tests.csproj
+++ b/src/CasCap.Common.Serialization.Tests/CasCap.Common.Serialization.Tests.csproj
@@ -12,20 +12,8 @@
     <ProjectReference Include="..\CasCap.Common.Serialization.MessagePack\CasCap.Common.Serialization.MessagePack.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.msbuild">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
   </ItemGroup>
 
 </Project>

--- a/src/CasCap.Common.Serialization.Tests/README.md
+++ b/src/CasCap.Common.Serialization.Tests/README.md
@@ -14,11 +14,8 @@ Verifies JSON and MessagePack serialization round-trips, custom converter behavi
 
 | Package |
 | --- |
-| [Microsoft.NET.Test.Sdk](https://www.nuget.org/packages/microsoft.net.test.sdk) |
 | [xunit.v3](https://www.nuget.org/packages/xunit.v3) |
-| [xunit.runner.visualstudio](https://www.nuget.org/packages/xunit.runner.visualstudio) |
-| [coverlet.collector](https://www.nuget.org/packages/coverlet.collector) |
-| [coverlet.msbuild](https://www.nuget.org/packages/coverlet.msbuild) |
+| [Microsoft.Testing.Extensions.CodeCoverage](https://www.nuget.org/packages/microsoft.testing.extensions.codecoverage) |
 
 ### Project References
 


### PR DESCRIPTION
## Summary

- Add `.github/instructions/bash.instructions.md` (structure, error handling, GitHub Actions annotations, testability, style) and wire it into the Instruction Files table
- Require extracting sizeable/critical composite-action `run:` logic into external, independently testable `.scripts/` files
- Require terse, one-line GitHub Actions input descriptions