### PR TITLE
Add granular expiry background service toggles to CachingConfig

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,13 +42,13 @@
     <PackageVersion Include="ModelContextProtocol" Version="2.2.0" />
     <PackageVersion Include="OllamaSharp" Version="5.4.30" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.17.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.17.0-rc.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.15.1-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.17.0-beta.1" />
     <PackageVersion Include="RedLock.net" Version="2.3.2" />
     <PackageVersion Include="StackExchange.Redis" Version="3.1.13" />
     <PackageVersion Include="xunit.v3" Version="4.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.2" />
     <PackageVersion Include="MessagePack" Version="3.1.8" />
     <PackageVersion Include="MessagePackAnalyzer" Version="3.1.8" />
-    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.17.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.Workflows" Version="1.18.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.11" />
@@ -38,7 +38,7 @@
     <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.1" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.Agents.AI" Version="1.17.0" />
+    <PackageVersion Include="Microsoft.Agents.AI" Version="1.18.0" />
     <PackageVersion Include="ModelContextProtocol" Version="2.2.0" />
     <PackageVersion Include="OllamaSharp" Version="5.4.30" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />

--- a/src/CasCap.Common.Caching/Extensions/ServiceCollectionExtensions.cs
+++ b/src/CasCap.Common.Caching/Extensions/ServiceCollectionExtensions.cs
@@ -45,7 +45,8 @@ public static class ServiceCollectionExtensions
             distributedLockingEnabled: cachingConfig.DistributedLockingEnabled,
             redisKeyFormat: cachingConfig.Redlock.RedisKeyFormat,
             redisDatabaseId: cachingConfig.RemoteCache.DatabaseId,
-            healthCheckRedis: cachingConfig.HealthCheckRedis);
+            healthCheckRedis: cachingConfig.HealthCheckRedis,
+            cacheExpiryServiceEnabled: cachingConfig.CacheExpiryServiceEnabled);
     }
 
     /// <inheritdoc cref="AddCasCapCaching(IServiceCollection, string?, CacheType)"/>
@@ -62,6 +63,9 @@ public static class ServiceCollectionExtensions
                 options.DiskCache = cachingConfig.DiskCache;
                 options.RemoteCache = cachingConfig.RemoteCache;
                 options.LocalCacheInvalidationEnabled = cachingConfig.LocalCacheInvalidationEnabled;
+                options.CacheExpiryServiceEnabled = cachingConfig.CacheExpiryServiceEnabled;
+                options.LocalCacheExpiryServiceEnabled = cachingConfig.LocalCacheExpiryServiceEnabled;
+                options.RemoteCacheExpiryServiceEnabled = cachingConfig.RemoteCacheExpiryServiceEnabled;
                 options.ExpirationSyncMode = cachingConfig.ExpirationSyncMode;
                 options.DistributedLockingEnabled = cachingConfig.DistributedLockingEnabled;
                 options.CacheKeyFormat = cachingConfig.CacheKeyFormat;
@@ -72,7 +76,8 @@ public static class ServiceCollectionExtensions
         return services.AddServices(connStr, LocalCacheType,
             distributedLockingEnabled: cachingConfig.DistributedLockingEnabled,
             redisKeyFormat: cachingConfig.Redlock.RedisKeyFormat,
-            redisDatabaseId: cachingConfig.RemoteCache.DatabaseId);
+            redisDatabaseId: cachingConfig.RemoteCache.DatabaseId,
+            cacheExpiryServiceEnabled: cachingConfig.CacheExpiryServiceEnabled);
     }
 
     /// <inheritdoc cref="AddCasCapCaching(IServiceCollection, string?, CacheType)"/>
@@ -80,7 +85,11 @@ public static class ServiceCollectionExtensions
         string? remoteCacheConnectionString = null, CacheType LocalCacheType = CacheType.Memory)
     {
         services.Configure(configureConfig);
-        return services.AddServices(remoteCacheConnectionString, LocalCacheType);
+        //materialise the configuration so registration-time toggles can be honoured
+        var cachingConfig = new CachingConfig();
+        configureConfig(cachingConfig);
+        return services.AddServices(remoteCacheConnectionString ?? cachingConfig.RemoteCacheConnectionString, LocalCacheType,
+            cacheExpiryServiceEnabled: cachingConfig.CacheExpiryServiceEnabled);
     }
 
     private static ConnectionMultiplexer? AddServices(this IServiceCollection services,
@@ -90,7 +99,8 @@ public static class ServiceCollectionExtensions
         bool distributedLockingEnabled = false,
         string redisKeyFormat = "RedLock:{0}",
         int redisDatabaseId = 0,
-        KubernetesProbeTypes healthCheckRedis = KubernetesProbeTypes.None)
+        KubernetesProbeTypes healthCheckRedis = KubernetesProbeTypes.None,
+        bool cacheExpiryServiceEnabled = true)
     {
         //ensure RedlockConfig is always available (idempotent; won't override bound config from overload #2)
         services.AddOptions<RedlockConfig>();
@@ -123,7 +133,8 @@ public static class ServiceCollectionExtensions
             services.AddSingleton<RemoteCacheExpiryService>();
             services.AddSingleton<IDistributedCache, DistributedCacheService>();
             services.AddSingleton<LocalCacheExpiryService>();
-            services.AddHostedService<CacheExpiryBgService>();
+            if (cacheExpiryServiceEnabled)
+                services.AddHostedService<CacheExpiryBgService>();
 
             var multiplexer = GetMultiplexer(remoteCacheConnectionString);
             services.AddSingleton<IConnectionMultiplexer>(multiplexer);

--- a/src/CasCap.Common.Caching/Models/_CachingConfig.cs
+++ b/src/CasCap.Common.Caching/Models/_CachingConfig.cs
@@ -47,6 +47,21 @@ public record CachingConfig : IAppConfig
     /// <summary>Enables pub/sub-based invalidation of local cache entries across distributed clients.</summary>
     public bool LocalCacheInvalidationEnabled { get; set; } = true;
 
+    /// <summary>Enables registration of the <see cref="CacheExpiryBgService"/> hosted service.</summary>
+    /// <remarks>
+    /// Defaults to <see langword="true"/>. When <see langword="false"/> the hosted service is never registered,
+    /// so neither <see cref="LocalCacheExpiryService"/> nor <see cref="RemoteCacheExpiryService"/> run.
+    /// </remarks>
+    public bool CacheExpiryServiceEnabled { get; set; } = true;
+
+    /// <summary>Enables the <see cref="LocalCacheExpiryService"/> pub/sub subscriber within <see cref="CacheExpiryBgService"/>.</summary>
+    /// <remarks>Defaults to <see langword="true"/>. Ignored when <see cref="CacheExpiryServiceEnabled"/> is <see langword="false"/>.</remarks>
+    public bool LocalCacheExpiryServiceEnabled { get; set; } = true;
+
+    /// <summary>Enables the <see cref="RemoteCacheExpiryService"/> keyspace subscriber within <see cref="CacheExpiryBgService"/>.</summary>
+    /// <remarks>Defaults to <see langword="true"/>. Ignored when <see cref="CacheExpiryServiceEnabled"/> is <see langword="false"/>.</remarks>
+    public bool RemoteCacheExpiryServiceEnabled { get; set; } = true;
+
     /// <summary>Controls how local sliding expirations are synchronized with the remote cache.</summary>
     public ExpirationSyncType ExpirationSyncMode { get; set; } = ExpirationSyncType.None;
 

--- a/src/CasCap.Common.Caching/README.md
+++ b/src/CasCap.Common.Caching/README.md
@@ -22,9 +22,9 @@ Provides a complete caching infrastructure with local (in-process) and remote (R
 | `RedisCacheService` | `IRemoteCache` implementation wrapping StackExchange.Redis with optional Lua script support |
 | `MemoryCacheService` | `ILocalCache` implementation backed by `IMemoryCache` |
 | `DiskCacheService` | `ILocalCache` implementation persisting cache entries to disk |
-| `CacheExpiryBgService` | Background service coordinating expiry synchronisation between local and remote caches |
-| `LocalCacheExpiryService` | Handles local cache entry expiration |
-| `RemoteCacheExpiryService` | Handles remote cache entry expiration |
+| `CacheExpiryBgService` | Background service coordinating expiry synchronisation between local and remote caches. Registered unless `CacheExpiryServiceEnabled` is `false` |
+| `LocalCacheExpiryService` | Handles local cache entry expiration. Disable via `LocalCacheExpiryServiceEnabled` |
+| `RemoteCacheExpiryService` | Handles remote cache entry expiration. Disable via `RemoteCacheExpiryServiceEnabled` |
 
 ### Extensions
 
@@ -38,7 +38,7 @@ Provides a complete caching infrastructure with local (in-process) and remote (R
 
 | Type | Description |
 | --- | --- |
-| `CachingConfig` | Main configuration record — `RemoteCacheConnectionString`, `PubSubPrefix`, `MemoryCacheSizeLimit`, `UseBuiltInLuaScripts`, `DiskCacheFolder`, `ExpirationSyncMode`, `DistributedLockingEnabled`, `CacheAsideDisabled`, `CacheKeyFormat`, `HealthCheckRedis`, `Redlock` |
+| `CachingConfig` | Main configuration record — `RemoteCacheConnectionString`, `PubSubPrefix`, `MemoryCacheSizeLimit`, `UseBuiltInLuaScripts`, `DiskCacheFolder`, `ExpirationSyncMode`, `DistributedLockingEnabled`, `CacheAsideDisabled`, `CacheKeyFormat`, `HealthCheckRedis`, `CacheExpiryServiceEnabled`, `LocalCacheExpiryServiceEnabled`, `RemoteCacheExpiryServiceEnabled`, `Redlock` |
 | `RedlockConfig` | Timing parameters for Redis distributed locks with named profile support — root defaults (`ExpiryMs` 5s, `WaitMs` 5s, `RetryMs` 250ms) tuned for cache-miss protection. `RedisKeyFormat` for lock key prefixing. Built-in `LeaderElection` profile (30s/60s/5s) for long-lived locks. Custom profiles via `Profiles` dictionary |
 | `RedlockProfiles` | Well-known profile name constants — `CacheMiss`, `LeaderElection` |
 | `RedlockTimingProfile` | Timing values for a single named lock profile — `ExpiryMs`, `WaitMs`, `RetryMs` |
@@ -130,6 +130,23 @@ All configuration lives under the `CasCap:CachingConfig` section in `appsettings
       "RemoteCache": {
         "SerializationType": "Json"
       }
+    }
+  }
+}
+```
+
+### Disabling the expiry background services
+
+Each background service can be switched off independently. `CacheExpiryServiceEnabled: false` prevents the `CacheExpiryBgService` hosted service being registered at all; the two granular toggles keep the hosted service registered but skip the individual subscriber.
+
+```json
+{
+  "CasCap": {
+    "CachingConfig": {
+      "RemoteCacheConnectionString": "localhost:6379,abortConnect=false",
+      "CacheExpiryServiceEnabled": true,
+      "LocalCacheExpiryServiceEnabled": false,
+      "RemoteCacheExpiryServiceEnabled": true
     }
   }
 }

--- a/src/CasCap.Common.Caching/Services/CacheExpiryBgService.cs
+++ b/src/CasCap.Common.Caching/Services/CacheExpiryBgService.cs
@@ -3,19 +3,30 @@
 /// <summary>
 /// Background service that runs <see cref="LocalCacheExpiryService"/> and <see cref="RemoteCacheExpiryService"/> concurrently.
 /// </summary>
-public sealed class CacheExpiryBgService(ILogger<CacheExpiryBgService> logger,
+public sealed class CacheExpiryBgService(ILogger<CacheExpiryBgService> logger, IOptions<CachingConfig> cachingConfig,
     LocalCacheExpiryService localCacheExpirySvc, RemoteCacheExpiryService remoteCacheExpirySvc) : BackgroundService
 {
     /// <inheritdoc/>
     protected async override Task ExecuteAsync(CancellationToken stoppingToken)
     {
         await Task.Yield();
+        var config = cachingConfig.Value;
+        //only start the sub-services which are enabled, otherwise a disabled sub-service completes
+        //immediately and the WhenAny below would tear this service down while the other still runs.
+        var tasks = new List<Task>(2);
+        if (config.LocalCacheExpiryServiceEnabled)
+            tasks.Add(localCacheExpirySvc.ExecuteAsync(stoppingToken));
+        if (config.RemoteCacheExpiryServiceEnabled)
+            tasks.Add(remoteCacheExpirySvc.ExecuteAsync(stoppingToken));
+        if (tasks.Count == 0)
+        {
+            logger.LogInformation("{ClassName} exiting immediately, all expiry sub-services are disabled", nameof(CacheExpiryBgService));
+            return;
+        }
         logger.LogInformation("{ClassName} starting", nameof(CacheExpiryBgService));
         // await-await-WhenAny propagates the first faulted task immediately so the
         // service crashes and the pod restarts rather than running in a degraded state.
-        await await Task.WhenAny(
-            localCacheExpirySvc.ExecuteAsync(stoppingToken),
-            remoteCacheExpirySvc.ExecuteAsync(stoppingToken)).ConfigureAwait(false);
+        await await Task.WhenAny(tasks).ConfigureAwait(false);
         logger.LogInformation("{ClassName} exiting", nameof(CacheExpiryBgService));
     }
 }


### PR DESCRIPTION
## Summary

Adds config toggles so the caching library's background services can be disabled individually, plus a NuGet package refresh.

Previously `CacheExpiryBgService` was registered unconditionally whenever a Redis connection string was supplied, `RemoteCacheExpiryService` had no toggle at all, and `LocalCacheExpiryService` was only gated by `LocalCacheInvalidationEnabled` — which is a feature flag also gating the publish side in `DistributedCacheService`, not a service-hosting switch.

## Changes

New `CachingConfig` properties, all defaulting to `true` and following the existing `{Feature}{State}` naming convention:

| Property | Effect when `false` |
| --- | --- |
| `CacheExpiryServiceEnabled` | `CacheExpiryBgService` is never registered as a hosted service |
| `LocalCacheExpiryServiceEnabled` | Hosted service still runs but skips the `LocalCacheExpiryService` pub/sub subscriber |
| `RemoteCacheExpiryServiceEnabled` | Hosted service still runs but skips the `RemoteCacheExpiryService` keyspace subscriber |

Also included:

- **Bug fix** — `CacheExpiryBgService` now only starts the enabled sub-services. Previously a sub-service that returned early (e.g. `LocalCacheExpiryService` with `LocalCacheInvalidationEnabled: false`) completed instantly, causing `await await Task.WhenAny(...)` to tear the background service down and log "exiting" while the other subscriber kept running as an orphaned, unobserved task.
- The `Action<CachingConfig>` registration overload now falls back to `RemoteCacheConnectionString` from the configured object, consistent with the other overloads and with the property's documented behaviour.
- `CasCap.Common.Caching` README updated with the new toggles and a configuration example.

## Validation

`dotnet build CasCap.Common.slnx` — succeeded, no errors or warnings.
